### PR TITLE
Implement clientWidth and clientHeight

### DIFF
--- a/package/android/src/main/java/com/webgpu/WebGPUView.java
+++ b/package/android/src/main/java/com/webgpu/WebGPUView.java
@@ -8,6 +8,7 @@ import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
 import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 
 public class WebGPUView extends SurfaceView implements SurfaceHolder.Callback {
@@ -37,7 +38,11 @@ public class WebGPUView extends SurfaceView implements SurfaceHolder.Callback {
 
   @Override
   public void surfaceCreated(@NonNull SurfaceHolder holder) {
-    onSurfaceCreate(holder.getSurface(), mContextId, this.getMeasuredWidth(), this.getMeasuredHeight());
+    float clientWidth = getWidth();
+    float clientHeight = getWidth();
+    float width = PixelUtil.toDIPFromPixel(clientWidth);
+    float height = PixelUtil.toDIPFromPixel(clientHeight);
+    onSurfaceCreate(holder.getSurface(), mContextId, clientWidth, clientHeight, width, height);
     mModule.onSurfaceCreated(mContextId);
   }
 
@@ -50,7 +55,14 @@ public class WebGPUView extends SurfaceView implements SurfaceHolder.Callback {
   }
 
   @DoNotStrip
-  private native void onSurfaceCreate(Surface surface, int contextId, int width, int height);
+  private native void onSurfaceCreate(
+    Surface surface,
+    int contextId,
+    float clientWidth,
+    float clientHeight,
+    float width,
+    float height
+  );
 
   @DoNotStrip
   private native void onSurfaceDestroy(int contextId);

--- a/package/cpp/rnwgpu/SurfaceRegistry.h
+++ b/package/cpp/rnwgpu/SurfaceRegistry.h
@@ -8,8 +8,10 @@
 namespace rnwgpu {
 
 struct SurfaceData {
-  int width = 0;
-  int height = 0;
+  float clientWidth = 0;
+  float clientHeight = 0;
+  float width = 0;
+  float height = 0;
   std::shared_ptr<wgpu::Surface> surface;
 };
 

--- a/package/cpp/rnwgpu/api/GPUCanvasContext.h
+++ b/package/cpp/rnwgpu/api/GPUCanvasContext.h
@@ -20,22 +20,28 @@ namespace m = margelo;
 
 class GPUCanvasContext : public m::HybridObject {
 public:
-  explicit GPUCanvasContext(wgpu::Surface instance, int width, int height, std::string label)
+  explicit GPUCanvasContext(const SurfaceData &surfaceData, std::string label)
       : HybridObject("GPUCanvasContext"),
-        _instance(instance),
-        _width(width),
-        _height(height),
+        _instance(*surfaceData.surface),
+        _clientWidth(surfaceData.clientWidth),
+        _clientHeight(surfaceData.clientHeight),
+        _width(surfaceData.width),
+        _height(surfaceData.height),
         _label(label) {}
 
 public:
   std::string getBrand() { return _name; }
-  int getWidth() { return _width; }
-  int getHeight() { return _height; }
+  float getWidth() { return _width; }
+  float getHeight() { return _height; }
+  float getClientWidth() { return _clientWidth; }
+  float getClientHeight() { return _clientHeight; }
 
   void loadHybridMethods() override {
     registerHybridGetter("__brand", &GPUCanvasContext::getBrand, this);
     registerHybridGetter("width", &GPUCanvasContext::getWidth, this);
     registerHybridGetter("height", &GPUCanvasContext::getHeight, this);
+    registerHybridGetter("clientWidth", &GPUCanvasContext::getClientWidth, this);
+    registerHybridGetter("clientHeight", &GPUCanvasContext::getClientHeight, this);
     registerHybridMethod("configure", &GPUCanvasContext::configure, this);
     registerHybridMethod("unconfigure", &GPUCanvasContext::unconfigure, this);
     registerHybridMethod("getCurrentTexture", &GPUCanvasContext::getCurrentTexture, this);
@@ -50,8 +56,10 @@ public:
 
 private:
   wgpu::Surface _instance;
-  int _width;
-  int _height;
+  float _clientWidth;
+  float _clientHeight;
+  float _width;
+  float _height;
   std::string _label;
 };
 


### PR DESCRIPTION
In [the previous PR](https://github.com/wcandillon/react-native-webgpu/pull/40), the implementation only included `context.width` and `context.height`. Here, I have implemented `clientWidth` and `clientHeight`.