### PR TITLE
Invoke gc() intermittently

### DIFF
--- a/package/example/src/components/useWebGPU.ts
+++ b/package/example/src/components/useWebGPU.ts
@@ -37,6 +37,7 @@ export const useWebGPU = (scene: Scene) => {
   const { device } = useDevice();
   useEffect(() => {
     let animationFrameId: number;
+    let frameNumber = 0;
 
     if (!device) {
       return;
@@ -66,12 +67,19 @@ export const useWebGPU = (scene: Scene) => {
     const renderScene = scene(sceneProps);
 
     const render = () => {
+      frameNumber++;
       const timestamp = Date.now();
       if (typeof renderScene === "function") {
         renderScene(timestamp);
       }
       device.queue.onSubmittedWorkDone().then(() => {
         context.present();
+        if (frameNumber > 2500) {
+          frameNumber = 0;
+          if (gc) {
+            gc();
+          }
+        }
         animationFrameId = requestAnimationFrame(render);
       });
     };


### PR DESCRIPTION
Invoking the `gc()`  periodically (but not too often) seem to provide satisfactory app memory usage and performance.
I originally tried to use the hermes `setExternalMemoryPressure` API but that didn't go well, I wrote up about my experience using it at https://github.com/facebook/hermes/issues/982#issuecomment-2258379047

This adds up to the list of things we need to do to present a frame. Hopefully we can offer a nice automatically frame scheduling model eventually, probably based on Reanimated.