### PR TITLE
use WaitForCommandsToBeScheduled() on iOS

### DIFF
--- a/package/cpp/rnwgpu/api/GPUCanvasContext.cpp
+++ b/package/cpp/rnwgpu/api/GPUCanvasContext.cpp
@@ -9,6 +9,7 @@ void GPUCanvasContext::configure(
   Convertor conv;
   wgpu::SurfaceConfiguration surfaceConfiguration;
   surfaceConfiguration.device = configuration->device->get();
+  _device = configuration->device->get();
   if (configuration->viewFormats.has_value()) {
     if (!conv(surfaceConfiguration.viewFormats,
               surfaceConfiguration.viewFormatCount,
@@ -37,6 +38,11 @@ std::shared_ptr<GPUTexture> GPUCanvasContext::getCurrentTexture() {
   return std::make_shared<GPUTexture>(texture, "");
 }
 
-void GPUCanvasContext::present() { _instance.Present(); }
+void GPUCanvasContext::present() {
+#ifdef __APPLE__
+  dawn::native::metal::WaitForCommandsToBeScheduled(_device.Get());
+#endif
+  _instance.Present();
+}
 
 } // namespace rnwgpu

--- a/package/cpp/rnwgpu/api/GPUCanvasContext.h
+++ b/package/cpp/rnwgpu/api/GPUCanvasContext.h
@@ -15,6 +15,22 @@
 #include "GPUTexture.h"
 #include "SurfaceRegistry.h"
 
+#ifdef __APPLE__
+
+namespace dawn {
+namespace native {
+namespace metal {
+
+// See https://source.chromium.org/chromium/chromium/src/+/main:third_party/dawn/include/dawn/native/MetalBackend.h;l=41
+void WaitForCommandsToBeScheduled(WGPUDevice device);
+
+}  // namespace metal
+}  // namespace native
+}  // namespace dawn
+
+#endif
+
+
 namespace rnwgpu {
 
 namespace m = margelo;
@@ -71,6 +87,7 @@ public:
 
 private:
   wgpu::Surface _instance;
+  wgpu::Device _device;
   std::shared_ptr<Canvas> _canvas;
 };
 

--- a/package/example/src/components/useWebGPU.ts
+++ b/package/example/src/components/useWebGPU.ts
@@ -72,16 +72,14 @@ export const useWebGPU = (scene: Scene) => {
       if (typeof renderScene === "function") {
         renderScene(timestamp);
       }
-      device.queue.onSubmittedWorkDone().then(() => {
-        context.present();
-        if (frameNumber > 2500) {
-          frameNumber = 0;
-          if (gc) {
-            gc();
-          }
+      context.present();
+      if (frameNumber > 2500) {
+        frameNumber = 0;
+        if (gc) {
+          gc();
         }
-        animationFrameId = requestAnimationFrame(render);
-      });
+      }
+      animationFrameId = requestAnimationFrame(render);
     };
 
     animationFrameId = requestAnimationFrame(render);


### PR DESCRIPTION
In Metal, queue.submit doesn't mean that the operations will be visible to other APIs/Metal devices right away.
Submitting other operations before the command buffer leads to incorrect rendering on some example on iOS.