### PR TITLE
Update gitignore to avoid package tgz bundles and local xcode env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ dist
 package/lib
 .vscode
 !package/script/build
+*.tgz

--- a/package/.gitignore
+++ b/package/.gitignore
@@ -29,6 +29,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
+.xcode.env.local
 
 # Android/IJ
 #

--- a/package/example/ios/.xcode.env.local
+++ b/package/example/ios/.xcode.env.local
@@ -1,2 +1,0 @@
-export NODE_BINARY=/opt/homebrew/bin/node
-


### PR DESCRIPTION
This PR updates .gitignore such that the following files aren't trakced:
1) package tgz output when building using `npm pack`
2) .xcode.env.local should be left out as it specifies local path to node (in this case it points to /opt)