### PR TITLE
fix: properly build xcframework

### DIFF
--- a/.github/workflows/build-dawn.yml
+++ b/.github/workflows/build-dawn.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           name: dawn-libs
           path: |
-            packages/webgpu/libs
+            packages/webgpu/libs/android
+            packages/webgpu/libs/ios/*.xcframework
             packages/webgpu/cpp/dawn
             packages/webgpu/cpp/webgpu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: yarn build
 
   build-android:
-    runs-on: macos-latest-large
+    runs-on: macos-latest
     env:
       TURBO_CACHE_DIR: .turbo/android
     steps:
@@ -126,7 +126,7 @@ jobs:
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   build-ios:
-    runs-on: macos-latest-large
+    runs-on: macos-latest
     env:
       TURBO_CACHE_DIR: .turbo/ios
     steps:

--- a/packages/webgpu/react-native-wgpu.podspec
+++ b/packages/webgpu/react-native-wgpu.podspec
@@ -15,11 +15,15 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/wcandillon/react-native-webgpu.git", :tag => "#{s.version}" }
 
   s.source_files = [
-    "ios/**/*.{h,c,cc,cpp,m,mm,swift}",  
+    "ios/**/*.{h,c,cc,cpp,m,mm,swift}",
     "cpp/**/*.{h,cpp}"
   ]
 
   s.vendored_frameworks = 'libs/apple/libwebgpu_dawn.xcframework'
+
+  s.pod_target_xcconfig = {
+    'HEADER_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/cpp',
+  }
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/packages/webgpu/react-native-wgpu.podspec
+++ b/packages/webgpu/react-native-wgpu.podspec
@@ -19,17 +19,7 @@ Pod::Spec.new do |s|
     "cpp/**/*.{h,cpp}"
   ]
 
-  s.ios.vendored_frameworks = [
-    'libs/apple/libwebgpu_dawn.xcframework',
-  ]
-
-  s.visionos.vendored_frameworks = [
-    'libs/apple/libwebgpu_dawn_visionos.xcframework',
-  ]
-
-  s.pod_target_xcconfig = {
-    'HEADER_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/cpp',
-  }
+  s.vendored_frameworks = 'libs/apple/libwebgpu_dawn.xcframework'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/packages/webgpu/scripts/build/dawn.ts
+++ b/packages/webgpu/scripts/build/dawn.ts
@@ -151,6 +151,16 @@ const apple = {
         `-library ${projectRoot}/libs/apple/universal_macosx/${lib}.a ` +
         ` -output ${projectRoot}/libs/apple/${lib}.xcframework `,
     );
+
+    // Remove intermediate libraries
+    $(
+      "rm -rf " +
+        `${projectRoot}/libs/apple/iphonesimulator` +
+        `${projectRoot}/libs/apple/arm64_iphoneos` +
+        `${projectRoot}/libs/apple/arm64_xros` +
+        `${projectRoot}/libs/apple/arm64_xrsimulator` +
+        `${projectRoot}/libs/apple/universal_macosx`,
+    );
   });
 
   console.log("Copy headers");

--- a/packages/webgpu/scripts/build/dawn.ts
+++ b/packages/webgpu/scripts/build/dawn.ts
@@ -84,7 +84,7 @@ const android = {
 const apple = {
   matrix: {
     arm64: platforms(["iphoneos", "iphonesimulator", "xros", "xrsimulator"]),
-    x86_64: platforms(["iphonesimulator", "xrsimulator"]),
+    x86_64: platforms(["iphonesimulator"]),
     universal: platforms(["macosx"]),
   },
   args: {
@@ -130,46 +130,26 @@ const apple = {
     }
   }
 
+  $(`mkdir -p ${projectRoot}/libs/apple/iphonesimulator`);
   libs.forEach((lib) => {
     console.log(`📱 Building fat binary for iphone simulator: ${lib}`);
     $(
-      `lipo -create ${projectRoot}/libs/apple/x86_64_iphonesimulator/${lib}.a ${projectRoot}/libs/apple/arm64_iphonesimulator/${lib}.a -output ${projectRoot}/libs/apple/${lib}.a`,
+      `lipo -create ${projectRoot}/libs/apple/x86_64_iphonesimulator/${lib}.a ${projectRoot}/libs/apple/arm64_iphonesimulator/${lib}.a -output ${projectRoot}/libs/apple/iphonesimulator/${lib}.a`,
     );
   });
 
   libs.forEach((lib) => {
-    console.log(`👓 Building fat binary for visionos simulator: ${lib}`);
-    $(
-      `lipo -create ${projectRoot}/libs/apple/x86_64_xrsimulator/${lib}.a ${projectRoot}/libs/apple/arm64_xrsimulator/${lib}.a -output ${projectRoot}/libs/apple/${lib}_visionos.a`,
-    );
-  });
+    console.log(`📱 Building ${lib} (XCFramework) for iOS, visionOS and macOS`);
 
-  libs.forEach((lib) => {
-    console.log(`📱 Building ${lib} for iOS`);
-    // iOS
     $(`rm -rf ${projectRoot}/libs/apple/${lib}.xcframework`);
     $(
       "xcodebuild -create-xcframework " +
-        `-library ${projectRoot}/libs/apple/${lib}.a ` +
+        `-library ${projectRoot}/libs/apple/iphonesimulator/${lib}.a ` +
         `-library ${projectRoot}/libs/apple/arm64_iphoneos/${lib}.a ` +
-        ` -output ${projectRoot}/libs/apple/${lib}.xcframework `,
-    );
-    console.log(`👓 Building ${lib} for VisionOS`);
-    // VisionOS
-    $(`rm -rf ${projectRoot}/libs/apple/${lib}_visionos.xcframework`);
-    $(
-      "xcodebuild -create-xcframework " +
-        `-library ${projectRoot}/libs/apple/${lib}_visionos.a ` +
         `-library ${projectRoot}/libs/apple/arm64_xros/${lib}.a ` +
-        ` -output ${projectRoot}/libs/apple/${lib}_visionos.xcframework `,
-    );
-    console.log(`🖥️ Building ${lib} for macOS`);
-    // macOS
-    $(`rm -rf ${projectRoot}/libs/apple/${lib}_macosx.xcframework`);
-    $(
-      "xcodebuild -create-xcframework " +
+        `-library ${projectRoot}/libs/apple/arm64_xrsimulator/${lib}.a ` +
         `-library ${projectRoot}/libs/apple/universal_macosx/${lib}.a ` +
-        ` -output ${projectRoot}/libs/apple/${lib}_macosx.xcframework `,
+        ` -output ${projectRoot}/libs/apple/${lib}.xcframework `,
     );
   });
 


### PR DESCRIPTION
Hey, 

This PR features multiple changes to fix how `xcframeworks` are handled. 

Changes included: 
- Move from `macos-latest-large` to `macos-latest` for the CI (Only `build-dawn.yml` requires M1 machine for now)
- Remove visionOS x86 build (building on Intel macs for visionOS is deprecated so lets not waste resources on this)
- I aligned `apple.toolchain.cmake` with upstream source code.
- Package only `xcframeworks` in build dawn job (currently the artifacts were over 450mbs because contained unnecessary stuff)

### Changes to build scripts

So before we created a bunch of xcframeworks then linked them for each platform. 

The whole idea behind xcframeworks is to have one bundle for multiple platforms(!). 

Before (contents generated by build-dawn job): 

![CleanShot 2024-09-20 at 14 36 12@2x](https://github.com/user-attachments/assets/81867d7f-46d2-4088-b2a0-9897590ad93a)

Now: 

![CleanShot 2024-09-20 at 14 35 31@2x](https://github.com/user-attachments/assets/2a7c833a-f50d-47b9-b2ea-489a40e7e83e)
