### PR TITLE
Disable turborepo cache on Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         env:
           JAVA_OPTS: "-XX:MaxHeapSize=6g"
         run: |
-          yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
+          yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}" --force
 
   build-ios:
     runs-on: macos-latest


### PR DESCRIPTION
because we want to use the apk for the e2e test, we need to build it fresh everytime