### PR TITLE
chore: gitignore artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ packages/webgpu/cpp/dawn/
 packages/webgpu/cpp/webgpu/
 packages/webgpu/lib
 !packages/webgpu/scripts/build
+artifacts/
 
 
 # Cocoapods


### PR DESCRIPTION
This change is split out from https://github.com/wcandillon/react-native-webgpu/pull/123. `yarn download-artifacts` will push download some binaries which show up in your git changed files list. Let's ignore them so we don't accidentally commit them. 