### PR TITLE
fix: Don't bundle as part of `"build:ios"

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -10,7 +10,7 @@
     "start": "react-native start",
     "pod:install": "pod install --project-directory=ios",
     "build:android": "cd android && ./gradlew assembleDebug --warning-mode all",
-    "build:ios": "yarn run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist && react-native build-ios --scheme Example --mode Debug --extra-params \"-sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO\"",
+    "build:ios": "react-native build-ios --scheme Example --mode Debug --extra-params \"-sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO\"",
     "mkdist": "node -e \"require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })\""
   },
   "dependencies": {


### PR DESCRIPTION
The `build:ios` script was first running `react-native bundle`. I think Turbo was not aware of this because `Turbo.json` doesn't list any JS files as input or output. Furthermore, `build:android` isn't bundling. Let's remove the not-obvious build step. 