### PR TITLE
Fix `undefined symbol: facebook::react::CallInvokerHolder::getCallInvoker()`

### DIFF
--- a/packages/webgpu/android/CMakeLists.txt
+++ b/packages/webgpu/android/CMakeLists.txt
@@ -85,5 +85,6 @@ target_link_libraries(
         android
         fbjni::fbjni
         ReactAndroid::jsi
+        ReactAndroid::reactnativejni
         webgpu_dawn
     )

--- a/packages/webgpu/android/build.gradle
+++ b/packages/webgpu/android/build.gradle
@@ -87,10 +87,10 @@ android {
   }
 
   packagingOptions {
-    exclude "lib/arm64-v8a/libjsi.so"
-    exclude "lib/x86_64/libjsi.so"
-    exclude "lib/x86/libjsi.so"
-    exclude "lib/armeabi-v7a/libjsi.so"
+    excludes = [
+      "**/libjsi.so",
+      "**/libreactnativejni.so",
+    ]
   }
 
   buildFeatures {


### PR DESCRIPTION
Fix for: `ld: error: undefined symbol: facebook::react::CallInvokerHolder::getCallInvoker()`

Now applications builds without errors:
<img width="327" alt="image" src="https://github.com/user-attachments/assets/597011a1-2611-4d91-8ac6-3fce5e2ed152">
