### PR TITLE
Add support for experimental android view implementations

### DIFF
--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -937,7 +937,7 @@ PODS:
     - React-debug
   - react-native-safe-area-context (4.11.0):
     - React-Core
-  - react-native-wgpu (0.1.17):
+  - react-native-wgpu (0.1.18):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1528,7 +1528,7 @@ SPEC CHECKSUMS:
   React-logger: 29fa3e048f5f67fe396bc08af7606426d9bd7b5d
   React-Mapbuffer: bf56147c9775491e53122a94c423ac201417e326
   react-native-safe-area-context: 851c62c48dce80ccaa5637b6aa5991a1bc36eca9
-  react-native-wgpu: f6685ff5fe24f54d833432a336f91703b0e68e9c
+  react-native-wgpu: 0f842ae9566fdf3b6ff05034bf9cbe99e90c2b5e
   React-nativeconfig: 9f223cd321823afdecf59ed00861ab2d69ee0fc1
   React-NativeModulesApple: ff7efaff7098639db5631236cfd91d60abff04c0
   React-perflogger: 32ed45d9cee02cf6639acae34251590dccd30994

--- a/packages/webgpu/android/src/main/java/com/webgpu/SurfaceView2.java
+++ b/packages/webgpu/android/src/main/java/com/webgpu/SurfaceView2.java
@@ -1,0 +1,79 @@
+package com.webgpu;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.PixelFormat;
+import android.os.Build;
+import android.view.Surface;
+import android.view.SurfaceControl;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+
+@SuppressLint("ViewConstructor")
+@RequiresApi(api = Build.VERSION_CODES.Q)
+public class SurfaceView2 extends SurfaceView implements SurfaceHolder.Callback {
+
+  WebGPUAPI mApi;
+  SurfaceControl mSurfaceControl;
+  Surface mSurface;
+
+  public SurfaceView2(Context context, WebGPUAPI api) {
+    super(context);
+    mApi = api;
+    getHolder().addCallback(this);
+  }
+
+  @Override
+  protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+    super.onLayout(changed, left, top, right, bottom);
+
+  }
+
+  @Override
+  protected void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
+  }
+
+  @Override
+  public void surfaceCreated(@NonNull SurfaceHolder holder) {
+    if (mSurfaceControl != null) {
+      SurfaceControl.Transaction tr = new SurfaceControl.Transaction();
+      tr.setVisibility(mSurfaceControl, true);
+      tr.reparent(mSurfaceControl, getSurfaceControl());
+      tr.apply();
+    } else {
+      SurfaceControl.Builder scb = new SurfaceControl.Builder();
+      scb.setName("WebGPUView");
+      scb.setOpaque(false);
+      scb.setBufferSize(getWidth(), getHeight());
+      scb.setParent(getSurfaceControl());
+      scb.setFormat(PixelFormat.RGBA_8888);
+      mSurfaceControl = scb.build();
+      mSurface = new Surface(mSurfaceControl);
+      mApi.surfaceCreated(mSurface);
+    }
+    SurfaceControl.Transaction tr = new SurfaceControl.Transaction();
+    tr.setVisibility(mSurfaceControl, true);
+    tr.apply();
+  }
+
+  @Override
+  public void surfaceChanged(@NonNull SurfaceHolder holder, int format, int width, int height) {
+    mApi.surfaceChanged(mSurface);
+    SurfaceControl.Transaction tr = new SurfaceControl.Transaction();
+    tr.setVisibility(mSurfaceControl, true);
+    tr.setBufferSize(mSurfaceControl, getWidth(), getHeight());
+    tr.apply();
+  }
+
+  @Override
+  public void surfaceDestroyed(@NonNull SurfaceHolder holder) {
+    SurfaceControl.Transaction tr = new SurfaceControl.Transaction();
+    tr.reparent(mSurfaceControl, null);
+    tr.apply();
+  }
+}

--- a/packages/webgpu/android/src/main/java/com/webgpu/WebGPUViewManager.java
+++ b/packages/webgpu/android/src/main/java/com/webgpu/WebGPUViewManager.java
@@ -1,6 +1,7 @@
 package com.webgpu;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -24,9 +25,9 @@ public class WebGPUViewManager extends WebGPUViewManagerSpec<WebGPUView> {
   }
 
   @Override
-  @ReactProp(name = "androidTransparency")
-  public void setAndroidTransparency(WebGPUView view, boolean value) {
-    view.setTransparent(value);
+  @ReactProp(name = "androidView")
+  public void setAndroidView(WebGPUView view, @Nullable String value) {
+    view.setView(value == null ? WebGPUView.SURFACE_VIEW : value);
   }
 
   @Override

--- a/packages/webgpu/android/src/oldarch/com/webgpu/WebGPUViewManagerSpec.java
+++ b/packages/webgpu/android/src/oldarch/com/webgpu/WebGPUViewManagerSpec.java
@@ -8,5 +8,5 @@ import com.facebook.react.uimanager.SimpleViewManager;
 
 public abstract class WebGPUViewManagerSpec<T extends View> extends SimpleViewManager<T> {
   public abstract void setContextId(T view, int contextId);
-  public abstract void setAndroidTransparency(T view, boolean transparency);
+  public abstract void setAndroidView(T view, @Nullable String name);
 }

--- a/packages/webgpu/package.json
+++ b/packages/webgpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-wgpu",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "React Native WebGPU",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/packages/webgpu/src/WebGPUViewNativeComponent.ts
+++ b/packages/webgpu/src/WebGPUViewNativeComponent.ts
@@ -4,7 +4,7 @@ import type { Int32 } from "react-native/Libraries/Types/CodegenTypes";
 
 interface NativeProps extends ViewProps {
   contextId?: Int32;
-  androidTransparency?: boolean;
+  androidView?: string;
 }
 
 // eslint-disable-next-line import/no-default-export


### PR DESCRIPTION
Add two experimental views that will eventually graduate as being the default for API Level >= 29:
* HardwareBuffer API: the fastest way have a WebGPU Canvas part of the Android compositor (much faster and efficient than TextureView). Currently the frame dropping policy is inferior to TextureView, once we fix it, we will graduate the view as the default.
* "SurfaceView2": an implementation of SurfaceView that uses the powerful SurfaceControl API. We currently use it to keep the surface alive when the app goes in the background but we plan to also use it for things like HRD support.