### PR TITLE
Fix Android build and linking on RN 0.76

### DIFF
--- a/packages/webgpu/android/CMakeLists.txt
+++ b/packages/webgpu/android/CMakeLists.txt
@@ -82,7 +82,20 @@ add_library(webgpu_dawn SHARED IMPORTED)
 set_property(TARGET webgpu_dawn PROPERTY IMPORTED_LOCATION "${WEBGPU_LIBS_PATH}/libwebgpu_dawn.so")
 
 # Link
-target_link_libraries(
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+    target_link_libraries(
+            ${PACKAGE_NAME}
+            ${FBJNI_LIBRARY}
+            log
+            jnigraphics
+            android
+            fbjni::fbjni
+            ReactAndroid::jsi
+            ReactAndroid::reactnative
+            webgpu_dawn
+        )
+else()
+    target_link_libraries(
         ${PACKAGE_NAME}
         ${FBJNI_LIBRARY}
         log
@@ -93,3 +106,4 @@ target_link_libraries(
         ReactAndroid::reactnativejni
         webgpu_dawn
     )
+endif()

--- a/packages/webgpu/src/NativeWebGPUModule.ts
+++ b/packages/webgpu/src/NativeWebGPUModule.ts
@@ -3,7 +3,6 @@ import { TurboModuleRegistry } from "react-native";
 
 export interface Spec extends TurboModule {
   install: () => boolean;
-  createSurfaceContext: (contextId: number) => boolean;
 }
 
 // eslint-disable-next-line import/no-default-export


### PR DESCRIPTION
When trying to run an app using the library on Android with React Native 0.76 I encountered two issues:

1.

```
WebGPUModule.java:22: error: WebGPUModule is not abstract and does not override abstract method createSurfaceContext(double) in NativeWebGPUModuleSpec
public class WebGPUModule extends NativeWebGPUModuleSpec {
```

The `createSurfaceContext` method implementation was indeed removed in #137 

2.
```
  CMake Error at CMakeLists.txt:26 (add_library):
    Target "react-native-wgpu" links to target "ReactAndroid::reactnativejni"
    but the target was not found.
```

This is likely because of the native library merge in 0.76: https://reactnative.dev/blog/2024/10/23/release-0.76-new-architecture#android-apps-are-38mb-smaller-thanks-to-native-library-merging

I think this should fix both of the errors. It works for me on React Native 0.76. However, I didn't manage to test it on older versions, as I get seemingly unrelated errors even without any changes.