### PR TITLE
Fix layout bug in Canvas

### DIFF
--- a/packages/webgpu/src/Canvas.tsx
+++ b/packages/webgpu/src/Canvas.tsx
@@ -137,7 +137,7 @@ export const Canvas = forwardRef<
   return (
     <View collapsable={false} ref={viewRef} onLayout={onLayout} {...props}>
       <WebGPUNativeView
-        style={{ flex: 1 }}
+        style={size}
         contextId={contextId}
         transparent={!!transparent}
       />


### PR DESCRIPTION
fixes the layout of the Canvas, we were maybe the wrong assumptions there where we assumed the `{ flex: 1 }` couldn't have side effects.

fixes #219 

