### PR TITLE
Fix the crash caused by UB in the C++ code

### DIFF
--- a/packages/webgpu/cpp/jsi/RNFJSIConverter.h
+++ b/packages/webgpu/cpp/jsi/RNFJSIConverter.h
@@ -28,6 +28,9 @@
 #include "Dispatcher.h"
 #include "ThreadPool.h"
 
+// This number is the maximum integer that can be represented exactly as a double
+#define MAX_SAFE_INTEGER uint64_t(9007199254740991)
+
 #if __has_include(<cxxabi.h>)
 #include <cxxabi.h>
 #endif
@@ -122,7 +125,7 @@ template <> struct JSIConverter<uint64_t> {
   static uint64_t fromJSI(jsi::Runtime& runtime, const jsi::Value& arg, bool outOfBound) {
     if (arg.isNumber()) {
       double value = arg.asNumber();
-      if (value < 0 || value > static_cast<double>(std::numeric_limits<uint64_t>::max())) {
+      if (value < 0 || value > MAX_SAFE_INTEGER) {
         throw jsi::JSError(runtime, "Number out of range for uint64_t");
       }
       return static_cast<uint64_t>(value);
@@ -132,7 +135,7 @@ template <> struct JSIConverter<uint64_t> {
   }
 
   static jsi::Value toJSI(jsi::Runtime& runtime, uint64_t arg) {
-    if (arg <= static_cast<uint64_t>(std::numeric_limits<double>::max())) {
+    if (arg <= MAX_SAFE_INTEGER) {
       return jsi::Value(static_cast<double>(arg));
     } else {
       throw jsi::JSError(runtime, "Number too large to be represented as a double");


### PR DESCRIPTION
The result of casting a double to uint64_t is undefined, if the double is greater than the numeric limits of uint64_t.

Fixes https://github.com/wcandillon/react-native-webgpu/issues/239