### PR TITLE
Fix: "Unimplemented component: <WebGPUView>" on iOS with New Architecture

### DIFF
--- a/packages/webgpu/package.json
+++ b/packages/webgpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-wgpu",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "React Native WebGPU",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
**Issue:**
When using `react-native-wgpu` with Expo (New Architecture enabled), the component fails to register and shows "Unimplemented component: \<WebGPUView\>".

**Root Cause:**
There's a typo in `package.json`'s `codegenConfig`. The property `componentProviders` (plural) should be `componentProvider` (singular) to match React Native's expected schema.

**Current (broken):**
```json
"ios": {
  "componentProviders": {
    "WebGPUView": "WebGPUView"
  }
}
```
**Should be:**
```json
"ios": {
  "componentProvider": {
    "WebGPUView": "WebGPUView"
  }
}
```

https://github.com/wcandillon/react-native-webgpu/issues/291