### PR TITLE
Replace GitHub Actions caching with ccache and hash-based checks

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,21 +14,16 @@ runs:
       with:
         node-version-file: .nvmrc
 
-    - name: Cache dependencies
-      id: yarn-cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          **/node_modules
-          .yarn/install-state.gz
-        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}-${{ hashFiles('**/package.json', '!node_modules/**') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          ${{ runner.os }}-yarn-
-
     - name: Install dependencies
-      if: steps.yarn-cache.outputs.cache-hit != 'true'
-      run: yarn install --immutable
+      run: |
+        HASH_FILE="/tmp/.yarn-lock-hash"
+        CURRENT_HASH=$(shasum yarn.lock | cut -d' ' -f1)
+        if [ -f "$HASH_FILE" ] && [ "$(cat "$HASH_FILE")" = "$CURRENT_HASH" ] && [ -d "node_modules" ]; then
+          echo "yarn.lock unchanged and node_modules exists — skipping install"
+        else
+          yarn install --immutable
+          echo "$CURRENT_HASH" > "$HASH_FILE"
+        fi
       shell: bash
 
     - name: Install Dawn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,13 @@ concurrency:
 jobs:
   build:
     runs-on: self-hosted
+    env:
+      CCACHE_DIR: /tmp/ccache
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          clean: false
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -33,17 +37,29 @@ jobs:
       - name: Typecheck files
         run: yarn tsc
 
-      - name: Cache CocoaPods
-        id: pods-cache
-        uses: actions/cache@v3
-        with:
-          path: apps/example/ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('apps/example/ios/Podfile.lock') }}
+      - name: Setup ccache
+        run: |
+          if ! command -v ccache &> /dev/null; then
+            echo "ccache not found — skipping"
+            echo "CCACHE_AVAILABLE=false" >> $GITHUB_ENV
+          else
+            ccache --set-config=max_size=5G
+            ccache --set-config=compression=true
+            ccache -z
+            echo "CCACHE_AVAILABLE=true" >> $GITHUB_ENV
+          fi
 
       - name: Install CocoaPods
-        if: steps.pods-cache.outputs.cache-hit != 'true'
         working-directory: apps/example/ios
-        run: pod install
+        run: |
+          HASH_FILE="/tmp/.podfile-lock-hash"
+          CURRENT_HASH=$(shasum Podfile.lock | cut -d' ' -f1)
+          if [ -f "$HASH_FILE" ] && [ "$(cat "$HASH_FILE")" = "$CURRENT_HASH" ] && [ -d "Pods" ]; then
+            echo "Podfile.lock unchanged and Pods exists — skipping pod install"
+          else
+            pod install
+            echo "$CURRENT_HASH" > "$HASH_FILE"
+          fi
 
       - name: Ensure Metro port is free
         run: |
@@ -53,17 +69,13 @@ jobs:
         working-directory: apps/example
         run: CI=true yarn start &
 
-      - name: Cache Xcode DerivedData
-        uses: actions/cache@v3
-        with:
-          path: apps/example/ios/build
-          key: ${{ runner.os }}-xcode-${{ hashFiles('apps/example/ios/Podfile.lock', 'packages/*/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-xcode-
-
       - name: Build example for iOS
         working-directory: apps/example/ios
         run: |
+          if [ "$CCACHE_AVAILABLE" = "true" ]; then
+            export CC="ccache clang"
+            export CXX="ccache clang++"
+          fi
           set -o pipefail && xcodebuild \
             -workspace example.xcworkspace \
             -scheme Example \
@@ -94,7 +106,6 @@ jobs:
           ")
             echo "Booting simulator $DEVICE_UDID"
             xcrun simctl boot "$DEVICE_UDID"
-            # Wait for the simulator to finish booting
             xcrun simctl bootstatus "$DEVICE_UDID" -b
           fi
 
@@ -106,6 +117,10 @@ jobs:
       - name: Run e2e tests
         working-directory: packages/webgpu
         run: yarn test
+
+      - name: ccache stats (iOS)
+        if: env.CCACHE_AVAILABLE == 'true'
+        run: ccache -s
 
       - name: Install NDK
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # v1.5.0
@@ -123,20 +138,17 @@ jobs:
       - name: Install Android SDK
         run: echo "sdk.dir=$ANDROID_HOME" > $GITHUB_WORKSPACE/apps/example/android/local.properties
 
-      - name: Cache Gradle
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/wrapper
-            ~/.gradle/caches
-            apps/example/android/app/build
-            apps/example/android/.gradle
-          key: ${{ runner.os }}-gradle-${{ hashFiles('apps/example/android/gradle/wrapper/gradle-wrapper.properties', 'packages/*/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: Build example for Android
         working-directory: apps/example/android
         env:
           JAVA_OPTS: "-XX:MaxHeapSize=6g"
-        run: ./gradlew assembleDebug --warning-mode all
+        run: |
+          if [ "$CCACHE_AVAILABLE" = "true" ]; then
+            export CC="ccache clang"
+            export CXX="ccache clang++"
+          fi
+          ./gradlew assembleDebug --build-cache --warning-mode all
+
+      - name: ccache stats (Android)
+        if: env.CCACHE_AVAILABLE == 'true'
+        run: ccache -s


### PR DESCRIPTION
## Summary
This PR replaces GitHub Actions' `actions/cache` with a more efficient caching strategy using ccache for C/C++ compilation and custom hash-based checks for dependency management. This approach reduces cache misses and improves build performance on self-hosted runners.

## Key Changes

- **Replaced CocoaPods caching**: Removed `actions/cache` for iOS Pods and implemented hash-based detection using `shasum` of `Podfile.lock`. Pod install is skipped if the lock file hasn't changed and Pods directory exists.

- **Replaced Xcode DerivedData caching**: Removed the explicit cache step for `apps/example/ios/build` directory, relying instead on ccache for compilation artifact caching.

- **Replaced Gradle caching**: Removed `actions/cache` for Gradle dependencies and build artifacts. Added `--build-cache` flag to Gradle invocation to leverage Gradle's built-in caching.

- **Replaced Yarn dependency caching**: Replaced `actions/cache` with hash-based detection in the setup action. Dependencies are only installed if `yarn.lock` hash has changed or `node_modules` doesn't exist.

- **Added ccache integration**: 
  - Set up ccache with 5GB max size and compression enabled
  - Configured C/C++ compiler wrappers (`CC` and `CXX`) to use ccache for both iOS and Android builds
  - Added ccache statistics reporting after iOS and Android builds
  - Made ccache optional with graceful fallback if not available

- **Improved checkout**: Added `clean: false` to checkout action to preserve workspace state between runs on self-hosted runners.

## Implementation Details

- Hash-based checks use `/tmp/` for storing hash files, making them persistent across workflow runs on self-hosted runners
- ccache availability is detected at runtime and stored in `GITHUB_ENV` for conditional use in subsequent steps
- All caching strategies maintain backward compatibility by skipping optimization steps if conditions aren't met

https://claude.ai/code/session_017SFCjKGRBpHqDgu7ijoG5N