### PR TITLE
Add GitHub Actions workflow for building Dawn binaries

### DIFF
--- a/.github/workflows/build-dawn.yml
+++ b/.github/workflows/build-dawn.yml
@@ -82,8 +82,10 @@ jobs:
     steps:
       - name: Checkout main repository
         uses: actions/checkout@v6.0.2
-        with:
-          submodules: recursive
+
+      - name: Checkout Dawn repository
+        run: |
+          git clone --depth 1 --branch ${{ needs.prepare-release.outputs.dawn_branch }} https://dawn.googlesource.com/dawn externals/dawn
 
       - name: Setup Android NDK
         id: setup-ndk
@@ -163,8 +165,10 @@ jobs:
     steps:
       - name: Checkout main repository
         uses: actions/checkout@v6.0.2
-        with:
-          submodules: recursive
+
+      - name: Checkout Dawn repository
+        run: |
+          git clone --depth 1 --branch ${{ needs.prepare-release.outputs.dawn_branch }} https://dawn.googlesource.com/dawn externals/dawn
 
       - name: Build ${{ matrix.platform }} ${{ matrix.arch }}
         run: |

--- a/.github/workflows/build-dawn.yml
+++ b/.github/workflows/build-dawn.yml
@@ -1,0 +1,249 @@
+name: Build Dawn
+
+on: workflow_dispatch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    outputs:
+      dawn_branch: ${{ steps.dawn_meta.outputs.branch }}
+      dawn_branch_slug: ${{ steps.dawn_meta.outputs.branch_slug }}
+      tag_name: ${{ steps.release_meta.outputs.tag_name }}
+      release_name: ${{ steps.release_meta.outputs.release_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Determine Dawn branch metadata
+        id: dawn_meta
+        run: |
+          set -eo pipefail
+          branch=$(git config -f .gitmodules submodule.externals/dawn.branch)
+          if [ -z "$branch" ]; then
+            echo "Could not determine Dawn branch from .gitmodules" >&2
+            exit 1
+          fi
+          slug=${branch//\//-}
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "branch_slug=$slug" >> "$GITHUB_OUTPUT"
+
+      - name: Compute release metadata
+        id: release_meta
+        run: |
+          tag="dawn-${DAWN_BRANCH_SLUG}"
+          echo "tag_name=$tag" >> "$GITHUB_OUTPUT"
+          echo "release_name=Dawn ${DAWN_BRANCH}" >> "$GITHUB_OUTPUT"
+        env:
+          DAWN_BRANCH: ${{ steps.dawn_meta.outputs.branch }}
+          DAWN_BRANCH_SLUG: ${{ steps.dawn_meta.outputs.branch_slug }}
+
+      - name: Create GitHub release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.release_meta.outputs.tag_name }}
+          name: ${{ steps.release_meta.outputs.release_name }}
+          body: "Dawn prebuilt binaries for version ${{ steps.dawn_meta.outputs.branch }}"
+          draft: false
+          prerelease: true
+          generate_release_notes: false
+
+  mobile-android:
+    needs: prepare-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64-v8a
+            cmake_args: -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-26
+            output_dir: externals/dawn/out/android_arm64-v8a
+            library_path: src/dawn/native/libwebgpu_dawn.so
+          - arch: armeabi-v7a
+            cmake_args: -DANDROID_ABI=armeabi-v7a -DANDROID_PLATFORM=android-26
+            output_dir: externals/dawn/out/android_armeabi-v7a
+            library_path: src/dawn/native/libwebgpu_dawn.so
+          - arch: x86
+            cmake_args: -DANDROID_ABI=x86 -DANDROID_PLATFORM=android-26
+            output_dir: externals/dawn/out/android_x86
+            library_path: src/dawn/native/libwebgpu_dawn.so
+          - arch: x86_64
+            cmake_args: -DANDROID_ABI=x86_64 -DANDROID_PLATFORM=android-26
+            output_dir: externals/dawn/out/android_x86_64
+            library_path: src/dawn/native/libwebgpu_dawn.so
+
+    name: Build-android-${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v6.0.2
+        with:
+          submodules: recursive
+
+      - name: Setup Android NDK
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27d
+
+      - name: Set ANDROID_NDK
+        run: echo "ANDROID_NDK=${{ steps.setup-ndk.outputs.ndk-path }}" >> $GITHUB_ENV
+
+      - name: Build android ${{ matrix.arch }}
+        run: |
+          cmake -S externals/dawn -B ${{ matrix.output_dir }} -G Ninja \
+            -DDAWN_MOBILE_BUILD=android \
+            -C externals/dawn/.github/workflows/dawn-ci.cmake \
+            -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+            ${{ matrix.cmake_args }} \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DDAWN_BUILD_MONOLITHIC_LIBRARY=SHARED \
+            -DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON \
+            -DCMAKE_EXE_LINKER_FLAGS="-llog" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-llog -Wl,-z,max-page-size=16384"
+          ninja -C ${{ matrix.output_dir }}
+
+      - name: Strip Android binaries
+        run: |
+          $ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip ${{ matrix.output_dir }}/${{ matrix.library_path }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-android-${{ matrix.arch }}
+          path: ${{ matrix.output_dir }}/${{ matrix.library_path }}
+
+      - name: Install headers (from arm64-v8a build only)
+        if: matrix.arch == 'arm64-v8a'
+        run: |
+          cmake --install ${{ matrix.output_dir }} --prefix dawn-headers
+
+      - name: Upload headers (from arm64-v8a build only)
+        if: matrix.arch == 'arm64-v8a'
+        uses: actions/upload-artifact@v7
+        with:
+          name: dawn-headers
+          path: dawn-headers/
+
+  mobile-apple:
+    needs: prepare-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ios
+            arch: arm64
+            cmake_args: -DPLATFORM=OS64 -DDEPLOYMENT_TARGET=14.0 -DENABLE_BITCODE=OFF -DENABLE_ARC=OFF -DENABLE_VISIBILITY=OFF
+            output_dir: externals/dawn/out/ios_arm64
+            library_path: src/dawn/native/libwebgpu_dawn.a
+          - platform: ios
+            arch: sim_arm64
+            cmake_args: -DPLATFORM=SIMULATORARM64 -DDEPLOYMENT_TARGET=14.0 -DENABLE_BITCODE=OFF -DENABLE_ARC=OFF -DENABLE_VISIBILITY=OFF
+            output_dir: externals/dawn/out/ios_sim_arm64
+            library_path: src/dawn/native/libwebgpu_dawn.a
+          - platform: ios
+            arch: sim_x86_64
+            cmake_args: -DPLATFORM=SIMULATOR64 -DDEPLOYMENT_TARGET=14.0 -DENABLE_BITCODE=OFF -DENABLE_ARC=OFF -DENABLE_VISIBILITY=OFF
+            output_dir: externals/dawn/out/ios_sim_x86_64
+            library_path: src/dawn/native/libwebgpu_dawn.a
+          - platform: macos
+            arch: universal
+            cmake_args: -DPLATFORM=MAC_UNIVERSAL -DDEPLOYMENT_TARGET=11.0 -DENABLE_BITCODE=OFF -DENABLE_ARC=OFF -DENABLE_VISIBILITY=OFF
+            output_dir: externals/dawn/out/macos_universal
+            library_path: src/dawn/native/libwebgpu_dawn.a
+
+    name: Build-${{ matrix.platform }}-${{ matrix.arch }}
+    runs-on: self-hosted
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v6.0.2
+        with:
+          submodules: recursive
+
+      - name: Build ${{ matrix.platform }} ${{ matrix.arch }}
+        run: |
+          cmake -S externals/dawn -B ${{ matrix.output_dir }} -G Ninja \
+            -DDAWN_MOBILE_BUILD=apple \
+            -C externals/dawn/.github/workflows/dawn-ci.cmake \
+            -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/packages/webgpu/scripts/build/apple.toolchain.cmake \
+            ${{ matrix.cmake_args }} \
+            -DCMAKE_BUILD_TYPE=Release
+          ninja -C ${{ matrix.output_dir }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-${{ matrix.platform }}-${{ matrix.arch }}
+          path: ${{ matrix.output_dir }}/${{ matrix.library_path }}
+
+  package-mobile:
+    name: Package Mobile Artifacts
+    runs-on: self-hosted
+    needs: [prepare-release, mobile-android, mobile-apple]
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: build-*
+          path: artifacts
+
+      - name: Download headers
+        uses: actions/download-artifact@v8
+        with:
+          name: dawn-headers
+          path: dawn-headers
+
+      - name: Create iOS Simulator fat binary
+        run: |
+          mkdir -p libs/apple/iphonesimulator
+          lipo -create \
+            artifacts/build-ios-sim_x86_64/libwebgpu_dawn.a \
+            artifacts/build-ios-sim_arm64/libwebgpu_dawn.a \
+            -output libs/apple/iphonesimulator/libwebgpu_dawn.a
+
+      - name: Create XCFramework
+        run: |
+          xcodebuild -create-xcframework \
+            -library libs/apple/iphonesimulator/libwebgpu_dawn.a \
+            -library artifacts/build-ios-arm64/libwebgpu_dawn.a \
+            -library artifacts/build-macos-universal/libwebgpu_dawn.a \
+            -output dawn-apple.xcframework
+
+      - name: Package Android libraries
+        run: |
+          mkdir -p dawn-android/arm64-v8a
+          mkdir -p dawn-android/armeabi-v7a
+          mkdir -p dawn-android/x86
+          mkdir -p dawn-android/x86_64
+          cp artifacts/build-android-arm64-v8a/libwebgpu_dawn.so dawn-android/arm64-v8a/
+          cp artifacts/build-android-armeabi-v7a/libwebgpu_dawn.so dawn-android/armeabi-v7a/
+          cp artifacts/build-android-x86/libwebgpu_dawn.so dawn-android/x86/
+          cp artifacts/build-android-x86_64/libwebgpu_dawn.so dawn-android/x86_64/
+
+      - name: Create archives
+        run: |
+          TAG="${{ needs.prepare-release.outputs.tag_name }}"
+          tar -czf dawn-android-${TAG}.tar.gz dawn-android
+          tar -czf dawn-apple-${TAG}.xcframework.tar.gz dawn-apple.xcframework
+          tar -czf dawn-headers-${TAG}.tar.gz dawn-headers
+
+      - name: Upload to GitHub release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.prepare-release.outputs.tag_name }}
+          files: |
+            dawn-android-${{ needs.prepare-release.outputs.tag_name }}.tar.gz
+            dawn-apple-${{ needs.prepare-release.outputs.tag_name }}.xcframework.tar.gz
+            dawn-headers-${{ needs.prepare-release.outputs.tag_name }}.tar.gz
+          prerelease: true


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automates the building and packaging of Dawn WebGPU binaries for mobile platforms (Android and Apple).

## Key Changes
- **New workflow file**: `.github/workflows/build-dawn.yml` that orchestrates the complete build and release process
- **Multi-platform builds**: Supports building for:
  - Android (arm64-v8a, armeabi-v7a, x86, x86_64)
  - iOS (arm64, simulator arm64, simulator x86_64)
  - macOS (universal binary)
- **Automated release management**: 
  - Extracts Dawn branch information from `.gitmodules`
  - Creates GitHub releases with appropriate versioning
  - Uploads compiled binaries and headers as release artifacts
- **Build optimization**:
  - Uses Android NDK r27d for Android builds
  - Strips Android binaries to reduce size
  - Creates iOS XCFramework for Apple platforms
  - Packages artifacts as compressed archives

## Implementation Details
- Workflow is triggered manually via `workflow_dispatch`
- Uses concurrency controls to prevent duplicate runs
- Implements a three-stage pipeline:
  1. **prepare-release**: Determines Dawn branch metadata and creates GitHub release
  2. **mobile-android** & **mobile-apple**: Parallel builds for each architecture
  3. **package-mobile**: Combines artifacts into platform-specific packages (XCFramework for Apple, organized directories for Android)
- Leverages self-hosted runners for Apple builds (iOS/macOS)
- Uploads final artifacts (Android libraries, iOS XCFramework, and headers) to the GitHub release

https://claude.ai/code/session_01U8oiT82kSDvY9e9pJJM5ao