### PR TITLE
fix(🧵): guard WebGPU bootstrap on secondary worklet runtimes

### DIFF
--- a/apps/example/src/Reanimated/List.tsx
+++ b/apps/example/src/Reanimated/List.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { RectButton } from "react-native-gesture-handler";
+import type { StackNavigationProp } from "@react-navigation/stack";
+
+import type { Routes } from "./Routes";
+
+export const examples = [
+  {
+    screen: "UIThread",
+    title: "🧵 UI Thread",
+  },
+  {
+    screen: "WorkletBootstrap",
+    title: "🧱 Worklet Bootstrap",
+  },
+] as const;
+
+const styles = StyleSheet.create({
+  container: {},
+  content: {
+    paddingBottom: 32,
+  },
+  thumbnail: {
+    backgroundColor: "white",
+    padding: 32,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  title: {},
+});
+
+export const List = () => {
+  const { navigate } = useNavigation<StackNavigationProp<Routes, "List">>();
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      {examples.map((thumbnail) => (
+        <RectButton
+          key={thumbnail.screen}
+          onPress={() => navigate(thumbnail.screen)}
+        >
+          <View style={styles.thumbnail}>
+            <Text style={styles.title}>{thumbnail.title}</Text>
+          </View>
+        </RectButton>
+      ))}
+    </ScrollView>
+  );
+};

--- a/apps/example/src/Reanimated/Reanimated.tsx
+++ b/apps/example/src/Reanimated/Reanimated.tsx
@@ -87,7 +87,7 @@ const webGPUDemo = (
   frame();
 };
 
-export function Reanimated() {
+export function UIThread() {
   const runAnimation = useSharedValue(true);
   const ref = useRef<CanvasRef>(null);
   useEffect(() => {

--- a/apps/example/src/Reanimated/Routes.ts
+++ b/apps/example/src/Reanimated/Routes.ts
@@ -1,0 +1,5 @@
+export type Routes = {
+  List: undefined;
+  UIThread: undefined;
+  WorkletBootstrap: undefined;
+};

--- a/apps/example/src/Reanimated/WorkletBootstrap.tsx
+++ b/apps/example/src/Reanimated/WorkletBootstrap.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { runOnJS, runOnUI } from "react-native-reanimated";
+// Importing from react-native-wgpu pulls in its barrel module (src/main),
+// whose top-level code runs WebGPUModule.install() and then patches
+// navigator.gpu / global.createImageBitmap from the native `RNWebGPU` global.
+//
+// That global is only fully populated on the MAIN JS runtime. On a secondary
+// worklet runtime (the Reanimated UI runtime here, or a Vision Camera frame
+// processor) `RNWebGPU` is undefined or a stripped-down stub. Referencing the
+// `Canvas` import inside the UI-thread worklet below forces the barrel to be
+// *required, and therefore evaluated, on the UI runtime*.
+//
+// Before the guards in src/main/index.tsx, that evaluation threw
+//   Cannot read property 'bind' of undefined
+// because it eagerly called `RNWebGPU.createImageBitmap.bind(RNWebGPU)` while
+// `createImageBitmap` was missing on the stub. A throw at module-evaluation
+// time poisons the whole module graph on that runtime, so every downstream
+// react-native-wgpu import there silently becomes undefined.
+//
+// This screen is a smoke test for that fix: if it reaches the "✅" state, the
+// package bootstrap survived evaluation on the secondary runtime.
+import { Canvas } from "react-native-wgpu";
+
+export const WorkletBootstrap = () => {
+  const [status, setStatus] = useState(
+    "Scheduling a worklet on the UI runtime…",
+  );
+
+  useEffect(() => {
+    runOnUI(() => {
+      "worklet";
+      // Touch the `Canvas` import so Reanimated requires (and evaluates) the
+      // react-native-wgpu barrel on THIS runtime. Pre-fix, the line above
+      // never runs because evaluation crashes here.
+      const canvasResolved = typeof Canvas === "function";
+      const navigatorOnUiRuntime =
+        typeof globalThis.navigator !== "undefined" &&
+        globalThis.navigator != null;
+      const gpuOnUiRuntime =
+        navigatorOnUiRuntime && globalThis.navigator.gpu != null;
+      runOnJS(setStatus)(
+        "✅ react-native-wgpu evaluated on the UI runtime without crashing.\n\n" +
+          `Canvas import resolved: ${canvasResolved}\n` +
+          `navigator present on UI runtime: ${navigatorOnUiRuntime}\n` +
+          `navigator.gpu present on UI runtime: ${gpuOnUiRuntime}\n\n` +
+          "(navigator.gpu is expected to be absent here: RNWebGPU is only " +
+          "fully populated on the main runtime. The point is that the module " +
+          "no longer crashes while figuring that out.)",
+      );
+    })();
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.status}>{status}</Text>
+      {/* Rendered on the JS thread so the `Canvas` import is unquestionably
+          retained by the bundler. */}
+      <Canvas style={styles.hiddenCanvas} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 24,
+    justifyContent: "center",
+  },
+  status: {
+    fontSize: 16,
+    lineHeight: 24,
+  },
+  hiddenCanvas: {
+    width: 1,
+    height: 1,
+    opacity: 0,
+  },
+});

--- a/apps/example/src/Reanimated/index.ts
+++ b/apps/example/src/Reanimated/index.ts
@@ -1,1 +1,0 @@
-export { Reanimated } from "./Reanimated";

--- a/apps/example/src/Reanimated/index.tsx
+++ b/apps/example/src/Reanimated/index.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { createStackNavigator } from "@react-navigation/stack";
+
+import type { Routes } from "./Routes";
+import { List } from "./List";
+import { UIThread } from "./Reanimated";
+import { WorkletBootstrap } from "./WorkletBootstrap";
+
+const Stack = createStackNavigator<Routes>();
+
+export const Reanimated = () => {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="List"
+        component={List}
+        options={{
+          title: "🎬 Reanimated",
+          header: () => null,
+        }}
+      />
+      <Stack.Screen
+        name="UIThread"
+        component={UIThread}
+        options={{
+          title: "🧵 UI Thread",
+        }}
+      />
+      <Stack.Screen
+        name="WorkletBootstrap"
+        component={WorkletBootstrap}
+        options={{
+          title: "🧱 Worklet Bootstrap",
+        }}
+      />
+    </Stack.Navigator>
+  );
+};

--- a/packages/webgpu/src/main/index.tsx
+++ b/packages/webgpu/src/main/index.tsx
@@ -12,27 +12,40 @@ const _installOk = WebGPUModule.install();
 
 registerWebGPUForReanimated();
 
-if (typeof RNWebGPU !== "undefined") {
-  if (!navigator) {
-    // @ts-expect-error Navigation object is more complex than this, setting it to an empty object to add gpu property
-    navigator = {
-      gpu: RNWebGPU.gpu,
-      userAgent: "react-native",
-    };
-  } else {
-    navigator.gpu = RNWebGPU.gpu;
-    if (typeof navigator.userAgent !== "string") {
-      try {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore - Hermes navigator may not include a userAgent, align with the polyfill if needed
-        navigator.userAgent = "react-native";
-      } catch {
-        // navigator.userAgent can be read-only; ignore if assignment fails
+// `RNWebGPU` is only fully populated in the main JS runtime where
+// WebGPUModule.install() was called against. When this bundle re-evaluates in
+// secondary worklet runtimes (Reanimated UI, Vision Camera frame processor,
+// etc.) `RNWebGPU` may either be undefined or be a stripped-down stub. Guard
+// every member access so a missing property doesn't take down the whole
+// module graph (which would surface as `Cannot read property 'bind' of
+// undefined` + every downstream import returning undefined).
+if (typeof RNWebGPU !== "undefined" && RNWebGPU != null) {
+  if (RNWebGPU.gpu) {
+    if (!navigator) {
+      // @ts-expect-error Navigation object is more complex than this, setting it to an empty object to add gpu property
+      navigator = {
+        gpu: RNWebGPU.gpu,
+        userAgent: "react-native",
+      };
+    } else {
+      navigator.gpu = RNWebGPU.gpu;
+      if (typeof navigator.userAgent !== "string") {
+        try {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore - Hermes navigator may not include a userAgent, align with the polyfill if needed
+          navigator.userAgent = "react-native";
+        } catch {
+          // navigator.userAgent can be read-only; ignore if assignment fails
+        }
       }
     }
   }
-  global.createImageBitmap =
-    global.createImageBitmap ?? RNWebGPU.createImageBitmap.bind(RNWebGPU);
+  if (
+    !global.createImageBitmap &&
+    typeof RNWebGPU.createImageBitmap === "function"
+  ) {
+    global.createImageBitmap = RNWebGPU.createImageBitmap.bind(RNWebGPU);
+  }
 } else {
   console.warn(
     `[react-native-wgpu] install() returned ${_installOk} but RNWebGPU global is not available`,


### PR DESCRIPTION
The src/main barrel runs WebGPUModule.install() and patches navigator.gpu / global.createImageBitmap at module-evaluation time. That code re-runs in every JS runtime the bundle is evaluated in, including secondary worklet runtimes (Reanimated UI, Vision Camera frame processors) where the native RNWebGPU global is only a stub.

Previously the bootstrap eagerly called
RNWebGPU.createImageBitmap.bind(RNWebGPU) whenever global.createImageBitmap was falsy. On a stub runtime createImageBitmap is missing, so .bind threw "Cannot read property 'bind' of undefined" during module evaluation, which poisons the whole module graph on that runtime (every downstream react-native-wgpu import becomes undefined).

Guard every member access so a missing property is a no-op instead of a crash: null-check RNWebGPU, only touch navigator when RNWebGPU.gpu exists, and only bind createImageBitmap when it is actually a function.

Adds a "Worklet Bootstrap" example under Reanimated that schedules a worklet referencing a react-native-wgpu import on the UI runtime, forcing the barrel to evaluate there. It reaches a success state on the fixed build and reproduces the crash if the guards are reverted.