### PR TITLE
test(🧪): run the e2e suite in-process via dawn.node with yarn test:node

### DIFF
--- a/packages/webgpu/package.json
+++ b/packages/webgpu/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "test": "NODE_OPTIONS='--experimental-require-module' jest -i",
     "test:ref": "REFERENCE=true NODE_OPTIONS='--experimental-require-module' jest -i",
+    "test:node": "NODE_WEBGPU=true NODE_OPTIONS='--experimental-require-module' jest -i",
     "test:plugin": "jest -c plugin/jest.config.js",
     "lint": "eslint . --ext .ts,.tsx  --max-warnings 0 --cache --fix",
     "tsc": "tsc --noEmit",
@@ -107,6 +108,7 @@
     "ts-morph": "^22.0.0",
     "tsx": "^4.20.5",
     "typescript": "^5.2.2",
+    "webgpu": "0.4.0",
     "wgpu-matrix": "^3.0.2",
     "ws": "^8.18.0",
     "yargs": "^17.7.2"

--- a/packages/webgpu/src/__tests__/config.ts
+++ b/packages/webgpu/src/__tests__/config.ts
@@ -1,2 +1,3 @@
 export const DEBUG = process.env.DEBUG === "true";
 export const REFERENCE = process.env.REFERENCE === "true";
+export const NODE_WEBGPU = process.env.NODE_WEBGPU === "true";

--- a/packages/webgpu/src/__tests__/globalSetup.ts
+++ b/packages/webgpu/src/__tests__/globalSetup.ts
@@ -1,6 +1,6 @@
 import { WebSocketServer } from "ws";
 
-import { REFERENCE } from "./config";
+import { NODE_WEBGPU, REFERENCE } from "./config";
 
 const isOS = (os: string): os is "android" | "ios" | "web" => {
   return ["ios", "android", "web"].indexOf(os) !== -1;
@@ -12,7 +12,9 @@ const isArch = (arc: string): arc is "paper" | "fabric" => {
 
 const globalSetup = () => {
   return new Promise<void>((resolve) => {
-    if (REFERENCE) {
+    // The reference (Chrome) and node (dawn.node) clients run in-process, so
+    // no device connection is needed.
+    if (REFERENCE || NODE_WEBGPU) {
       resolve();
       return;
     }

--- a/packages/webgpu/src/__tests__/setup.ts
+++ b/packages/webgpu/src/__tests__/setup.ts
@@ -480,6 +480,72 @@ class NodeTestingClient implements TestingClient {
       throw new Error("dawn.node returned no WebGPU adapter");
     }
     this.device = await adapter.requestDevice();
+    this.installWebPolyfills(this.device);
+  }
+
+  // dawn.node implements the core WebGPU API but none of the web-platform
+  // image machinery, so provide the minimal pieces the specs rely on.
+  private installWebPolyfills(device: GPUDevice) {
+    const decodePng = (bytes: Uint8Array) => {
+      const png = PNG.sync.read(
+        Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength),
+      );
+      return {
+        data: new Uint8ClampedArray(png.data),
+        width: png.width,
+        height: png.height,
+        close() {},
+      };
+    };
+    (globalThis as Record<string, unknown>).createImageBitmap = async (
+      source: unknown,
+    ) => {
+      if (source instanceof ArrayBuffer) {
+        return decodePng(new Uint8Array(source));
+      }
+      if (ArrayBuffer.isView(source)) {
+        return decodePng(
+          new Uint8Array(source.buffer, source.byteOffset, source.byteLength),
+        );
+      }
+      if (typeof Blob !== "undefined" && source instanceof Blob) {
+        return decodePng(new Uint8Array(await source.arrayBuffer()));
+      }
+      if (
+        source !== null &&
+        typeof source === "object" &&
+        "data" in source &&
+        "width" in source
+      ) {
+        // Already an ImageData-like object (e.g. one of the test assets).
+        return source;
+      }
+      throw new Error("createImageBitmap polyfill: unsupported source");
+    };
+    // copyExternalImageToTexture expects an ImageBitmap; route the raw RGBA
+    // bytes of our ImageData-like sources through writeTexture instead.
+    Object.defineProperty(device.queue, "copyExternalImageToTexture", {
+      configurable: true,
+      value: (
+        source: {
+          source: { data: Uint8ClampedArray; width: number; height: number };
+        },
+        destination: GPUTexelCopyTextureInfo,
+        copySize: GPUExtent3DStrict,
+      ) => {
+        const { data, width } = source.source;
+        device.queue.writeTexture(
+          destination,
+          new Uint8Array(
+            data.buffer as ArrayBuffer,
+            data.byteOffset,
+            data.byteLength,
+          ),
+          { bytesPerRow: width * 4 },
+          copySize,
+        );
+      },
+    });
   }
 
   async dispose() {

--- a/packages/webgpu/src/__tests__/setup.ts
+++ b/packages/webgpu/src/__tests__/setup.ts
@@ -6,7 +6,7 @@ import path from "path";
 import puppeteer from "puppeteer";
 import { PNG } from "pngjs";
 import pixelmatch from "pixelmatch";
-import type { mat4, vec3, mat3 } from "wgpu-matrix";
+import { mat4, vec3, mat3 } from "wgpu-matrix";
 import type { Server, WebSocket } from "ws";
 import type { Browser, Page } from "puppeteer";
 
@@ -14,7 +14,7 @@ import type { GPUOffscreenCanvas } from "../Offscreen";
 
 import { cubeVertexArray } from "./components/cube";
 import { redFragWGSL, triangleVertWGSL } from "./components/triangle";
-import { DEBUG, REFERENCE } from "./config";
+import { DEBUG, NODE_WEBGPU, REFERENCE } from "./config";
 
 jest.setTimeout(180 * 1000);
 
@@ -74,7 +74,13 @@ interface TestingClient {
 export let client: TestingClient;
 
 beforeAll(async () => {
-  client = REFERENCE ? new ReferenceTestingClient() : new RemoteTestingClient();
+  if (REFERENCE) {
+    client = new ReferenceTestingClient();
+  } else if (NODE_WEBGPU) {
+    client = new NodeTestingClient();
+  } else {
+    client = new RemoteTestingClient();
+  }
   await client.init();
 });
 
@@ -331,6 +337,156 @@ class ReferenceTestingClient implements TestingClient {
     if (this.browser && !DEBUG) {
       this.browser.close();
     }
+  }
+}
+
+// Offscreen render target mirroring the DrawingContext the reference client
+// injects into the Chrome page: getCurrentTexture() returns a plain texture
+// and getImageData() reads it back through a mapped buffer.
+class NodeDrawingContext {
+  private texture: GPUTexture;
+  private buffer: GPUBuffer;
+
+  constructor(
+    private device: GPUDevice,
+    private format: GPUTextureFormat,
+    readonly width: number,
+    readonly height: number,
+  ) {
+    this.texture = device.createTexture({
+      size: [width, height],
+      format,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    });
+    this.buffer = device.createBuffer({
+      size: width * 4 * height,
+      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    });
+  }
+
+  get canvas() {
+    return { width: this.width, height: this.height };
+  }
+
+  getCurrentTexture() {
+    return this.texture;
+  }
+
+  async getImageData(): Promise<BitmapData> {
+    const commandEncoder = this.device.createCommandEncoder();
+    const bytesPerRow = this.width * 4;
+    commandEncoder.copyTextureToBuffer(
+      { texture: this.texture },
+      { buffer: this.buffer, bytesPerRow },
+      [this.width, this.height],
+    );
+    this.device.queue.submit([commandEncoder.finish()]);
+    await this.buffer.mapAsync(GPUMapMode.READ);
+    const data = Array.from(new Uint8Array(this.buffer.getMappedRange()));
+    this.buffer.unmap();
+    return {
+      data,
+      width: this.width,
+      height: this.height,
+      format: this.format,
+    };
+  }
+}
+
+class NodeTestingClient implements TestingClient {
+  readonly OS = "node" as const;
+  readonly arch = "paper" as const;
+
+  private gpu: GPU | null = null;
+  private device: GPUDevice | null = null;
+
+  async eval<C = Ctx, R = JSONValue>(
+    fn: (ctx: GPUTestingContext & C) => R | Promise<R>,
+    ctx?: C,
+  ): Promise<R> {
+    if (!this.gpu || !this.device) {
+      throw new Error("NodeTestingClient not initialized. Did you call init?");
+    }
+    const { gpu } = this;
+    const { device } = this;
+    const drawingContext = new NodeDrawingContext(
+      device,
+      gpu.getPreferredCanvasFormat(),
+      1024,
+      1024,
+    );
+    const fTexturePath = path.join(
+      __dirname,
+      "../../../../apps/example/src/assets/f.png",
+    );
+    const fTextureBase64 = `data:image/png;base64,${fs.readFileSync(fTexturePath).toString("base64")}`;
+    const toImageData = (relPath: string) => {
+      const bitmap = decodeImage(relPath);
+      // Node has no ImageData constructor; a structurally compatible object
+      // is enough for writeTexture-based tests.
+      return {
+        data: new Uint8ClampedArray(bitmap.data),
+        width: bitmap.width,
+        height: bitmap.height,
+        colorSpace: "srgb",
+      } as ImageData;
+    };
+    const base = {
+      gpu,
+      device,
+      shaders: { triangleVertWGSL, redFragWGSL },
+      urls: { fTexture: fTextureBase64 },
+      assets: {
+        cubeVertexArray,
+        di3D: toImageData("../../../../apps/example/src/assets/Di-3d.png"),
+        moon: toImageData("../../../../apps/example/src/assets/moon.png"),
+        saturn: toImageData("../../../../apps/example/src/assets/saturn.png"),
+      },
+      ctx: drawingContext as unknown as GPUCanvasContext,
+      canvas: {
+        width: drawingContext.width,
+        height: drawingContext.height,
+        getImageData: () => drawingContext.getImageData(),
+      } as unknown as GPUOffscreenCanvas,
+      mat4,
+      vec3,
+      mat3,
+    };
+    return fn(Object.assign(base, ctx) as GPUTestingContext & C);
+  }
+
+  async init() {
+    // Load the prebuilt dawn.node binary directly: the package's index.js is
+    // ESM-only (import.meta), which jest's CommonJS transform cannot load.
+    const arch = process.platform === "darwin" ? "universal" : process.arch;
+    const { create, globals } = require(
+      `webgpu/dist/${process.platform}-${arch}.dawn.node`,
+    ) as {
+      create: (flags: string[]) => GPU;
+      globals: Record<string, unknown>;
+    };
+    // Expose GPUBufferUsage, GPUTextureUsage, GPUMapMode, ... to test code.
+    Object.assign(globalThis, globals);
+    (globalThis as Record<string, unknown>).RNWebGPU = {
+      DecodeToUTF8: (data: NodeJS.ArrayBufferView) =>
+        new TextDecoder().decode(data),
+    };
+    // Same instance-level toggles as the native runtime (see GPU.cpp).
+    this.gpu = create([
+      "enable-dawn-features=allow_unsafe_apis,expose_wgsl_experimental_features",
+    ]);
+    const adapter = await this.gpu.requestAdapter();
+    if (!adapter) {
+      throw new Error("dawn.node returned no WebGPU adapter");
+    }
+    this.device = await adapter.requestDevice();
+  }
+
+  async dispose() {
+    this.device?.destroy();
+    // Drop the reference to the dawn.node instance so node can exit.
+    this.device = null;
+    this.gpu = null;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20411,6 +20411,7 @@ __metadata:
     ts-morph: ^22.0.0
     tsx: ^4.20.5
     typescript: ^5.2.2
+    webgpu: 0.4.0
     wgpu-matrix: ^3.0.2
     ws: ^8.18.0
     yargs: ^17.7.2
@@ -24504,6 +24505,16 @@ __metadata:
   version: 0.3.7
   resolution: "webdriver-bidi-protocol@npm:0.3.7"
   checksum: e069eb14c4857656e13603e02c7cadd73c69af5d97b61389c47aad35cbe92fa59c54bf04ccdc81dea6fe3246b87d3e4a082732e4ed7ab27546cc613bc155729d
+  languageName: node
+  linkType: hard
+
+"webgpu@npm:0.4.0":
+  version: 0.4.0
+  resolution: "webgpu@npm:0.4.0"
+  dependencies:
+    "@webgpu/types": ^0.1.69
+    debug: ^4.4.0
+  checksum: e7cc0632a273fdcecbe9094048b43be060875e8f487d43c387fa7728abf22a759a4bbe48e0f7833c6b3f111f309aff5d59f78bffcc8be62bbd619671496f3b1a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds a NodeTestingClient that executes client.eval directly against the webgpu npm package (Dawn's node bindings) instead of shipping the code to a device over WebSocket or to Chrome via puppeteer. The eval function runs in-process against the same offscreen DrawingContext the reference client injects into Chrome, so existing specs and snapshots work unchanged. NODE_WEBGPU=true selects the client and skips the WebSocket test server, mirroring how REFERENCE=true works.

The dawn.node binary is loaded directly from webgpu/dist because the package entry point is ESM-only, which jest's CommonJS transform cannot load.