### PR TITLE
fix(⏰): cache RuntimeContext by runtime address instead of runtimeData

### DIFF
--- a/packages/webgpu/cpp/rnwgpu/async/RuntimeContext.cpp
+++ b/packages/webgpu/cpp/rnwgpu/async/RuntimeContext.cpp
@@ -7,14 +7,12 @@
 #include <ReactCommon/CallInvoker.h>
 
 #include "AsyncTaskHandle.h"
+#include "RuntimeRegistry.h"
 #include "WGPULogger.h"
 
 namespace rnwgpu::async {
 
 namespace {
-struct RuntimeData {
-  std::shared_ptr<RuntimeContext> context;
-};
 constexpr const char *TAG = "RuntimeContext";
 
 // The main JS runtime and its CallInvoker, registered once on install. The
@@ -31,6 +29,11 @@ std::mutex &processEventsMutex() {
   static std::mutex mutex;
   return mutex;
 }
+
+RuntimeRegistry<jsi::Runtime, RuntimeContext> &runtimeContexts() {
+  static RuntimeRegistry<jsi::Runtime, RuntimeContext> registry;
+  return registry;
+}
 } // namespace
 
 void RuntimeContext::registerMainRuntime(
@@ -46,28 +49,21 @@ RuntimeContext::RuntimeContext(jsi::Runtime &runtime, wgpu::Instance instance)
 }
 
 std::shared_ptr<RuntimeContext> RuntimeContext::get(jsi::Runtime &runtime) {
-  auto data = runtime.getRuntimeData(runtimeDataUUID());
-  if (!data) {
-    return nullptr;
-  }
-  return std::static_pointer_cast<RuntimeData>(data)->context;
+  return runtimeContexts().get(&runtime);
 }
 
 std::shared_ptr<RuntimeContext>
 RuntimeContext::getOrCreate(jsi::Runtime &runtime, wgpu::Instance instance) {
-  if (auto existing = get(runtime)) {
-    return existing;
-  }
-  auto context = std::make_shared<RuntimeContext>(runtime, std::move(instance));
-  // Only the main JS runtime's context carries the CallInvoker; it is used to
-  // deliver spontaneous events (device.lost) without the pump.
-  if (&runtime == sMainRuntime) {
-    context->_callInvoker = sMainInvoker;
-  }
-  auto data = std::make_shared<RuntimeData>();
-  data->context = context;
-  runtime.setRuntimeData(runtimeDataUUID(), data);
-  return context;
+  return runtimeContexts().getOrCreate(&runtime, [&runtime, &instance] {
+    auto context =
+        std::make_shared<RuntimeContext>(runtime, std::move(instance));
+    // Only the main JS runtime's context carries the CallInvoker; it is used
+    // to deliver spontaneous events (device.lost) without the pump.
+    if (&runtime == sMainRuntime) {
+      context->_callInvoker = sMainInvoker;
+    }
+    return context;
+  });
 }
 
 AsyncTaskHandle RuntimeContext::postTask(const TaskCallback &callback,
@@ -183,11 +179,6 @@ void RuntimeContext::tick() {
   if (_pumpTasks.load(std::memory_order_acquire) > 0) {
     requestTick();
   }
-}
-
-jsi::UUID RuntimeContext::runtimeDataUUID() {
-  static const auto uuid = jsi::UUID();
-  return uuid;
 }
 
 } // namespace rnwgpu::async

--- a/packages/webgpu/cpp/rnwgpu/async/RuntimeContext.h
+++ b/packages/webgpu/cpp/rnwgpu/async/RuntimeContext.h
@@ -24,8 +24,8 @@ namespace rnwgpu::async {
 /**
  * Per-runtime coordinator for asynchronous WebGPU operations.
  *
- * Each JS runtime that uses WebGPU gets its own RuntimeContext, stored in the
- * runtime's runtimeData. Async Dawn operations are registered with
+ * Each JS runtime that uses WebGPU gets its own RuntimeContext, cached by the
+ * stable runtime address. Async Dawn operations are registered with
  * CallbackMode::AllowProcessEvents and driven to completion by pumping
  * `instance.ProcessEvents()` on the runtime's OWN thread via a self-
  * rescheduling tick (scheduled through that runtime's setTimeout). Because
@@ -102,8 +102,6 @@ public:
   void onTaskSettled(bool keepPumping);
 
 private:
-  static jsi::UUID runtimeDataUUID();
-
   void requestTick();
   void tick();
   void drainMailbox();

--- a/packages/webgpu/cpp/rnwgpu/async/RuntimeRegistry.h
+++ b/packages/webgpu/cpp/rnwgpu/async/RuntimeRegistry.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+
+namespace rnwgpu::async {
+
+// Address-keyed cache of per-runtime singletons. Used instead of
+// jsi::Runtime::set/getRuntimeData: Hermes backs runtimeData with a DenseMap
+// whose reserved empty key is the default-constructed (all-zero) jsi::UUID,
+// so caching under jsi::UUID() reads uninitialized buckets and crashes on any
+// runtime that already carries other runtime data (e.g. react-native-worklets
+// runtimes). The host keeps each jsi::Runtime object stable for its lifetime,
+// so its address is a safe identity; expired entries are pruned lazily.
+template <typename Key, typename Value> class RuntimeRegistry {
+public:
+  std::shared_ptr<Value> get(Key *key) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = _entries.find(key);
+    if (it == _entries.end()) {
+      return nullptr;
+    }
+    auto value = it->second.lock();
+    if (!value) {
+      _entries.erase(it);
+    }
+    return value;
+  }
+
+  template <typename Factory>
+  std::shared_ptr<Value> getOrCreate(Key *key, Factory &&factory) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto &slot = _entries[key];
+    if (auto value = slot.lock()) {
+      return value;
+    }
+    std::shared_ptr<Value> value = std::forward<Factory>(factory)();
+    slot = value;
+    return value;
+  }
+
+private:
+  std::mutex _mutex;
+  std::unordered_map<Key *, std::weak_ptr<Value>> _entries;
+};
+
+} // namespace rnwgpu::async


### PR DESCRIPTION
## Summary
WebGPU crashes natively (EXC_BAD_ACCESS) when it's used from a worklet runtime, e.g. navigator.gpu.requestAdapter() or GPUBuffer.mapAsync() from the Reanimated UI thread. On the main JS runtime it works fine. Also all those accesses are via TypeGPU and I didn't test the raw WebGPU cases but I reckon it's the exact same

I'm not a Hermes/C++ expert, so i don't fully grasp why the crashes happened exactly but i gathered the .ips logs from crashes and run them through Fable which produced a fix that works for me locally

# Everything that follows (both the explanation and the fix is authored by AI and is attached just as a hypothesis and potential fix that worked for me, please take that into account while looking) - feel free to take over this branch or close this in favor of a better fix

Two on-device .ips crash reports, both from GPUBuffer.mapAsync called on the Reanimated UI runtime

```
Report 1, EXC_BAD_ACCESS (SIGKILL), KERN_PROTECTION_FAILURE at 0x0:
0  ???        0x0
1  hermesvm   HermesRuntimeImpl::setRuntimeDataImpl(jsi::UUID const&, ...) + 84
2  <app>      jsi::WithRuntimeDecorator<worklets::AroundLock, ...>::setRuntimeDataImpl(...)
3  <app>      rnwgpu::async::RuntimeContext::getOrCreate(jsi::Runtime&, wgpu::Instance) + 248
4  <app>      rnwgpu::GPUBuffer::mapAsync(jsi::Runtime&, ...) + 168
```

```
Report 2, EXC_BAD_ACCESS (SIGSEGV), KERN_INVALID_ADDRESS at 0x8e0008:
0  <app>      jsi::Runtime::getRuntimeData(jsi::UUID const&) + 32
1  <app>      rnwgpu::async::RuntimeContext::get(jsi::Runtime&) + 44
2  <app>      rnwgpu::async::RuntimeContext::getOrCreate(jsi::Runtime&, wgpu::Instance) + 40
3  <app>      rnwgpu::GPUBuffer::mapAsync(jsi::Runtime&, ...) + 168
   ...        worklets::WorkletRuntime::runSync(...) -> executeQueueForProMotion
```

Both fault inside Hermes' set/getRuntimeData on the way out of RuntimeContext::get/getOrCreate, and only on a worklet runtime. I disassembled the shipping hermesvm binary (Mach-O UUID matched the reports) and the faulting instructions read/delete an uninitialized bucket in the map Hermes keeps behind runtimeData.

### What

RuntimeContext cached itself on the runtime via jsi::Runtime::set/getRuntimeData with a default-constructed (all-zero) jsi::UUID as the key. Hermes seems to reserve that exact all-zero UUID as the "empty slot" marker in that map, so reading or writing under it hits uninitialized memory. On the main runtime WebGPU is the first thing to use runtimeData so it happens to work; on worklet runtimes (Reanimated seeds runtimeData first) the first WebGPU call reads or frees garbage, which is the two crashes above.

### Fix

Stop using runtimeData. Cache RuntimeContext in a small static, mutex-guarded map keyed by thmeRegistry.h). The runtime object stays put for its lifetime so its address is a safe key,entries are weak_ptrs (the GPU objects already own the context), and stale entries get pruned lazily. Sidesteps the UUID issue entirely and behaves the same across JS engines.