### PR TITLE
Add thread-safe synchronization for prototype cache access

### DIFF
--- a/packages/webgpu/cpp/jsi/NativeObject.h
+++ b/packages/webgpu/cpp/jsi/NativeObject.h
@@ -235,6 +235,10 @@ public:
    * Each NativeObject<Derived> type has its own static cache.
    * Uses StaticRuntimeAwareCache to properly handle runtime lifecycle
    * and hot reload (where the main runtime is destroyed and recreated).
+   *
+   * Callers must hold getPrototypeCacheMutex(): the cache is reached
+   * concurrently from the main JS thread (create()) and from worklet
+   * runtime threads (BoxedWebGPUObject::unbox() -> installPrototype()).
    */
   static RuntimeAwareCache<PrototypeCacheEntry> &
   getPrototypeCache(jsi::Runtime &runtime) {
@@ -243,10 +247,21 @@ public:
   }
 
   /**
+   * Per-class mutex guarding getPrototypeCache() and prototype
+   * installation. Serializes the StaticRuntimeAwareCache pointer swap
+   * (hot reload) and the per-runtime cache lookups.
+   */
+  static std::mutex &getPrototypeCacheMutex() {
+    static std::mutex mutex;
+    return mutex;
+  }
+
+  /**
    * Ensure the prototype is installed for this runtime.
    * Called automatically by create(), but can be called manually.
    */
   static void installPrototype(jsi::Runtime &runtime) {
+    std::lock_guard<std::mutex> lock(getPrototypeCacheMutex());
     auto &entry = getPrototypeCache(runtime).get(runtime);
     if (entry.prototype.has_value()) {
       return; // Already installed
@@ -303,6 +318,7 @@ public:
 
     installPrototype(runtime);
 
+    std::lock_guard<std::mutex> lock(getPrototypeCacheMutex());
     auto &entry = getPrototypeCache(runtime).get(runtime);
     if (!entry.prototype.has_value()) {
       return;
@@ -346,14 +362,17 @@ public:
     obj.setNativeState(runtime, instance);
 
     // Set prototype
-    auto &entry = getPrototypeCache(runtime).get(runtime);
-    if (entry.prototype.has_value()) {
-      // Use Object.setPrototypeOf to set the prototype
-      auto objectCtor =
-          runtime.global().getPropertyAsObject(runtime, "Object");
-      auto setPrototypeOf =
-          objectCtor.getPropertyAsFunction(runtime, "setPrototypeOf");
-      setPrototypeOf.call(runtime, obj, *entry.prototype);
+    {
+      std::lock_guard<std::mutex> lock(getPrototypeCacheMutex());
+      auto &entry = getPrototypeCache(runtime).get(runtime);
+      if (entry.prototype.has_value()) {
+        // Use Object.setPrototypeOf to set the prototype
+        auto objectCtor =
+            runtime.global().getPropertyAsObject(runtime, "Object");
+        auto setPrototypeOf =
+            objectCtor.getPropertyAsFunction(runtime, "setPrototypeOf");
+        setPrototypeOf.call(runtime, obj, *entry.prototype);
+      }
     }
 
     // Set memory pressure hint for GC

--- a/packages/webgpu/cpp/jsi/RuntimeAwareCache.cpp
+++ b/packages/webgpu/cpp/jsi/RuntimeAwareCache.cpp
@@ -2,6 +2,6 @@
 
 namespace rnwgpu {
 
-jsi::Runtime *BaseRuntimeAwareCache::_mainRuntime = nullptr;
+std::atomic<jsi::Runtime *> BaseRuntimeAwareCache::_mainRuntime{nullptr};
 
 } // namespace rnwgpu

--- a/packages/webgpu/cpp/jsi/RuntimeAwareCache.h
+++ b/packages/webgpu/cpp/jsi/RuntimeAwareCache.h
@@ -2,8 +2,10 @@
 
 #include <jsi/jsi.h>
 
+#include <atomic>
 #include <cassert>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <utility>
 
@@ -15,17 +17,22 @@ namespace jsi = facebook::jsi;
 
 class BaseRuntimeAwareCache {
 public:
-  static void setMainJsRuntime(jsi::Runtime *rt) { _mainRuntime = rt; }
+  static void setMainJsRuntime(jsi::Runtime *rt) {
+    // Atomic: hot reload rewrites this from the JS thread while worklet
+    // runtime threads read it concurrently.
+    _mainRuntime.store(rt, std::memory_order_release);
+  }
   static jsi::Runtime *getMainJsRuntime() {
-    assert(_mainRuntime != nullptr &&
+    auto *rt = _mainRuntime.load(std::memory_order_acquire);
+    assert(rt != nullptr &&
            "Expected main Javascript runtime to be set in the "
            "BaseRuntimeAwareCache class.");
 
-    return _mainRuntime;
+    return rt;
   }
 
 private:
-  static jsi::Runtime *_mainRuntime;
+  static std::atomic<jsi::Runtime *> _mainRuntime;
 };
 
 /**
@@ -56,7 +63,10 @@ class RuntimeAwareCache : public BaseRuntimeAwareCache,
 public:
   void onRuntimeDestroyed(jsi::Runtime *rt) override {
     if (getMainJsRuntime() != rt) {
-      // We are removing a secondary runtime
+      // We are removing a secondary runtime. This is invoked by
+      // RuntimeLifecycleMonitor on the destroyed runtime's thread, which may
+      // run concurrently with get() on another runtime's thread.
+      std::lock_guard<std::mutex> lock(_secondaryCachesMutex);
       _secondaryRuntimeCaches.erase(rt);
     }
   }
@@ -75,6 +85,14 @@ public:
     if (getMainJsRuntime() == &rt) {
       return _primaryCache;
     } else {
+      // Guard the secondary map: it can be mutated concurrently by get()
+      // on a worklet runtime's thread and by onRuntimeDestroyed() when
+      // another secondary runtime is torn down. The main-runtime path above
+      // stays lock-free. References into the map remain valid after the
+      // lock is released (unordered_map never invalidates references on
+      // insert/erase of other keys, and this runtime's entry can only be
+      // erased from this runtime's own thread).
+      std::lock_guard<std::mutex> lock(_secondaryCachesMutex);
       if (_secondaryRuntimeCaches.count(&rt) == 0) {
         // we only add listener when the secondary runtime is used, this assumes
         // that the secondary runtime is terminated first. This lets us avoid
@@ -88,11 +106,12 @@ public:
         T cache;
         _secondaryRuntimeCaches.emplace(&rt, std::move(cache));
       }
+      return _secondaryRuntimeCaches.at(&rt);
     }
-    return _secondaryRuntimeCaches.at(&rt);
   }
 
 private:
+  std::mutex _secondaryCachesMutex;
   std::unordered_map<void *, T> _secondaryRuntimeCaches;
   T _primaryCache;
 };


### PR DESCRIPTION
## Summary
This PR adds proper thread synchronization to protect concurrent access to the prototype cache in NativeObject and the main runtime pointer in RuntimeAwareCache. These changes ensure thread safety when the prototype cache is accessed simultaneously from the main JS thread and worklet runtime threads.

## Key Changes

- **NativeObject.h**: 
  - Added `getPrototypeCacheMutex()` static method to provide per-class mutex guarding prototype cache access
  - Added mutex locks in `installPrototype()` to serialize cache lookups and prototype installation
  - Added mutex locks in `create()` method when accessing the prototype cache
  - Updated documentation to clarify that callers must hold the mutex when accessing the prototype cache

- **RuntimeAwareCache.h**:
  - Changed `_mainRuntime` from a raw pointer to `std::atomic<jsi::Runtime *>` to safely handle concurrent reads/writes during hot reload
  - Updated `setMainJsRuntime()` to use atomic store with release semantics
  - Updated `getMainJsRuntime()` to use atomic load with acquire semantics
  - Added `_secondaryCachesMutex` to guard concurrent access to `_secondaryRuntimeCaches` map
  - Added mutex locks in `onRuntimeDestroyed()` when erasing secondary runtime caches
  - Added mutex locks in `get()` when accessing the secondary runtime caches map
  - Added detailed comments explaining the concurrency model and why certain paths remain lock-free

- **RuntimeAwareCache.cpp**:
  - Updated static initialization of `_mainRuntime` to use atomic type with nullptr initializer

## Implementation Details

The synchronization strategy distinguishes between:
- **Main runtime path**: Lock-free atomic operations for the primary cache (performance-critical)
- **Secondary runtime path**: Mutex-protected map access to handle concurrent modifications from multiple worklet threads
- **Prototype cache**: Per-class mutex serializing both hot reload (cache pointer swap) and per-runtime lookups

This ensures thread safety while maintaining performance for the common single-threaded case.

https://claude.ai/code/session_01YX8eZT7KVhRPKNPVQDZ2rt