### PR TITLE
fix(🐛): add duplicate brand validation and JSON serialization for NativeObjects

### DIFF
--- a/packages/webgpu/cpp/jsi/NativeObject.h
+++ b/packages/webgpu/cpp/jsi/NativeObject.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -48,6 +49,12 @@ public:
 
   void registerInstaller(const std::string &brand, InstallerFunc installer) {
     std::lock_guard<std::mutex> lock(_mutex);
+    if (_installers.count(brand) != 0) {
+      // The brand is the key unbox() uses to rebuild objects on worklet
+      // runtimes - a duplicate would let one class hijack another's unboxing.
+      throw std::runtime_error("Duplicate native object brand registered: " +
+                               brand);
+    }
     _installers[brand] = std::move(installer);
   }
 
@@ -292,6 +299,49 @@ public:
       descriptor.setProperty(runtime, "configurable", true);
       defineProperty.call(runtime, prototype, toStringTag, descriptor);
     }
+
+    // Install a generic toJSON so JSON.stringify works: data properties live
+    // as getters on this shared prototype, and JSON.stringify only serializes
+    // own enumerable properties (so it would otherwise produce {}).
+    auto toJSON = jsi::Function::createFromHostFunction(
+        runtime, jsi::PropNameID::forUtf8(runtime, "toJSON"), 0,
+        [](jsi::Runtime &rt, const jsi::Value &thisVal,
+           const jsi::Value * /*args*/, size_t /*count*/) -> jsi::Value {
+          auto thisObj = thisVal.getObject(rt);
+          auto objectCtor = rt.global().getPropertyAsObject(rt, "Object");
+          auto getPrototypeOf =
+              objectCtor.getPropertyAsFunction(rt, "getPrototypeOf");
+          auto proto = getPrototypeOf.call(rt, thisObj);
+          jsi::Object result(rt);
+          if (!proto.isObject()) {
+            return std::move(result);
+          }
+          auto getOwnPropertyNames =
+              objectCtor.getPropertyAsFunction(rt, "getOwnPropertyNames");
+          auto names =
+              getOwnPropertyNames.call(rt, proto).getObject(rt).getArray(rt);
+          size_t length = names.size(rt);
+          for (size_t i = 0; i < length; i++) {
+            auto nameValue = names.getValueAtIndex(rt, i);
+            if (!nameValue.isString()) {
+              continue;
+            }
+            auto name = nameValue.getString(rt).utf8(rt);
+            if (name == "constructor" || name == "toJSON") {
+              continue;
+            }
+            // Read off `this` so prototype getters evaluate against the
+            // object's native state. Getters that throw keep throwing.
+            auto value = thisObj.getProperty(rt, name.c_str());
+            if (value.isObject() && value.getObject(rt).isFunction(rt)) {
+              // Skip methods - JSON.stringify would drop them anyway
+              continue;
+            }
+            result.setProperty(rt, name.c_str(), value);
+          }
+          return std::move(result);
+        });
+    prototype.setProperty(runtime, "toJSON", toJSON);
 
     // Cache the prototype
     entry.prototype = std::move(prototype);

--- a/packages/webgpu/src/__tests__/GPU.spec.ts
+++ b/packages/webgpu/src/__tests__/GPU.spec.ts
@@ -252,6 +252,26 @@ describe("Adapter", () => {
     expect(result.maxTextureDimension2D).toBeGreaterThanOrEqual(2048);
     expect(result.maxTextureDimension3D).toBeGreaterThanOrEqual(256);
   });
+  it("serializes prototype getters via JSON.stringify (toJSON)", async () => {
+    const result = await client.eval(({ gpu }) => {
+      return gpu.requestAdapter().then((adapter) => {
+        const limits = JSON.parse(JSON.stringify(adapter!.limits));
+        const adapterJson = JSON.parse(JSON.stringify(adapter!));
+        return {
+          limits,
+          adapterKeys: Object.keys(adapterJson),
+        };
+      });
+    });
+    // Getters on the prototype must survive a JSON round-trip
+    expect(result.limits.maxBindGroups).toBeGreaterThan(0);
+    expect(result.limits.maxBufferSize).toBeGreaterThan(0);
+    expect(result.limits.maxTextureDimension2D).toBeGreaterThanOrEqual(2048);
+    // Nested NativeObjects serialize deeply (adapter.limits via adapter)
+    expect(result.adapterKeys).toContain("limits");
+    // Methods on the prototype must not appear in JSON output
+    expect(result.adapterKeys).not.toContain("requestDevice");
+  });
   it("getPreferredCanvasFormat", async () => {
     const result = await client.eval(({ gpu }) => {
       return gpu.getPreferredCanvasFormat();


### PR DESCRIPTION
## Summary
This PR enhances the NativeObject registry with safety checks and improves JSON serialization support for native objects with prototype-based getters.

## Key Changes
- **Duplicate brand validation**: Added a check in `registerInstaller()` to prevent registering multiple installers with the same brand name, throwing a `std::runtime_error` if a duplicate is detected. This prevents one class from hijacking another's unboxing mechanism.
- **JSON serialization support**: Implemented a generic `toJSON()` method on the NativeObject prototype that enables `JSON.stringify()` to properly serialize data properties defined as getters on the prototype. The implementation:
  - Iterates through prototype property names using `Object.getOwnPropertyNames()`
  - Skips special properties (`constructor`, `toJSON`) and methods
  - Reads property values from the instance (so prototype getters evaluate against the object's native state)
  - Returns a plain object with serializable properties
- **Test coverage**: Added a comprehensive test case verifying that:
  - Prototype getters survive JSON round-trips
  - Nested NativeObjects serialize deeply
  - Methods are excluded from JSON output

## Implementation Details
The `toJSON()` implementation uses `Object.getPrototypeOf()` and `Object.getOwnPropertyNames()` to discover serializable properties, ensuring that getters are properly evaluated in the context of the instance's native state while maintaining the expected JSON.stringify behavior of excluding methods and non-enumerable properties.

https://claude.ai/code/session_01HkMGQ9BNHcdeuwy5SkeGb9