### PR TITLE
chore(🐙): minor doc update

### DIFF
--- a/apps/docs/content/api/install-webgpu.mdx
+++ b/apps/docs/content/api/install-webgpu.mdx
@@ -76,7 +76,7 @@ runOnRuntime(runtime, gpuWork)(device);
 
 ### navigator.gpu on a worklet runtime
 
-After `installWebGPU()`, a worklet can request its own adapter and device instead of receiving them from the main thread. The returned promises settle on the calling runtime.
+After `installWebGPU()`, read `navigator` through `globalThis.navigator` inside a worklet. The Worklets babel plugin does not currently treat a bare `navigator` as a known global, so without the prefix it captures the main runtime's `navigator` object by closure instead of reading the one installed on the worklet runtime. This is fixed upstream ([software-mansion/react-native-reanimated#10364](https://github.com/software-mansion/react-native-reanimated/pull/10364)); once you are on a version of `react-native-worklets` that includes it, a bare `navigator` works and the prefix is no longer needed.
 
 ```tsx twoslash
 import { installWebGPU } from "react-native-webgpu";
@@ -85,17 +85,15 @@ import { runOnUI } from "react-native-worklets";
 runOnUI(() => {
   "worklet";
   installWebGPU();
+  const format = globalThis.navigator.gpu.getPreferredCanvasFormat();
   globalThis.navigator.gpu.requestAdapter().then((adapter) => {
     // …
   });
 })();
 ```
 
-## Known limitations
+If you create a device on the worklet runtime, beware that spontaneous device events are only delivered for devices created on the main JS runtime:
+- `device.lost` read on a worklet runtime returns a promise that never settles, unless the device is already lost at that point, in which case it resolves normally.
+- `uncapturederror` listeners registered on a device created on a worklet runtime never fire.
 
-* `globalThis.navigator` instead of `navigator`: inside a worklet, read `navigator` through `globalThis.navigator`. The Worklets babel plugin does not currently treat a bare `navigator` as a known global, so without the prefix it captures the main runtime's `navigator` object by closure instead of reading the one installed on the worklet runtime. This is fixed upstream ([software-mansion/react-native-reanimated#10364](https://github.com/software-mansion/react-native-reanimated/pull/10364)); once you are on a version of `react-native-worklets` that includes it, a bare `navigator` works and the prefix is no longer needed.
-* `device.lost` and `uncapturederror` are main-thread only: spontaneous device events are only delivered for devices created on the main JS runtime:
-  - `device.lost` read on a worklet runtime returns a promise that never settles, unless the device is already lost at that point, in which case it resolves normally.
-  - `uncapturederror` listeners registered on a device created on a worklet runtime never fire.
-  
-  If you need to observe device loss or uncaptured errors, create the device on the main JS thread, attach the handlers there, and pass the device into the worklet.
+If you need to observe device loss or uncaptured errors, create the device on the main JS thread, attach the handlers there, and pass the device into the worklet.


### PR DESCRIPTION
Clarify usage of globalThis.navigator in worklets and document known limitations regarding device events.