### PR TITLE
fix(🌎): avoid implicit web canvas resize

### DIFF
--- a/packages/webgpu/src/WebGPUViewNativeComponent.web.ts
+++ b/packages/webgpu/src/WebGPUViewNativeComponent.web.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import { StyleSheet } from "react-native";
 import type { Int32 } from "react-native/Libraries/Types/CodegenTypes";
 import type { ViewProps } from "react-native";
@@ -10,65 +10,15 @@ export interface NativeProps extends ViewProps {
   transparent: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function debounce<T extends (...args: any[]) => void>(
-  func: T,
-  wait: number,
-  immediate = false,
-) {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  return function debounced(
-    this: ThisParameterType<T>,
-    ...args: Parameters<T>
-  ) {
-    const context = this;
-    const callNow = immediate && !timeout;
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-    timeout = setTimeout(() => {
-      timeout = undefined;
-      if (!immediate) {
-        func.apply(context, args);
-      }
-    }, wait);
-    if (callNow) {
-      func.apply(context, args);
-    }
-  };
-}
-
-function resizeCanvas(canvas: HTMLCanvasElement | null) {
-  if (!canvas) {
-    return;
-  }
-
-  const dpr = window.devicePixelRatio || 1;
-
-  const { height, width } = canvas.getBoundingClientRect();
-  canvas.setAttribute("height", (height * dpr).toString());
-  canvas.setAttribute("width", (width * dpr).toString());
-}
-
 // eslint-disable-next-line import/no-default-export
 export default function WebGPUViewNativeComponent(
   props: NativeProps,
 ): React.JSX.Element {
   const { contextId, style, transparent, ...rest } = props;
 
-  const canvasElm = useRef<HTMLCanvasElement>();
-
-  useEffect(() => {
-    const onResize = debounce(
-      () => resizeCanvas(canvasElm.current ?? null),
-      100,
-    );
-    window.addEventListener("resize", onResize);
-    return () => {
-      window.removeEventListener("resize", onResize);
-    };
-  }, []);
-
+  // MakeWebGPUCanvasContext sets the initial drawing-buffer size. Subsequent
+  // resizes belong to the renderer so it can recreate depth/MSAA attachments
+  // together; changing canvas.width/height here would invalidate its textures.
   return React.createElement("canvas", {
     ...rest,
     id: contextIdToId(contextId),
@@ -77,12 +27,6 @@ export default function WebGPUViewNativeComponent(
       ...styles.flex1,
       ...(transparent === false ? { backgroundColor: "white" } : {}),
       ...(typeof style === "object" ? style : {}),
-    },
-    ref: (ref: HTMLCanvasElement) => {
-      canvasElm.current = ref;
-      if (ref) {
-        resizeCanvas(ref);
-      }
     },
   });
 }


### PR DESCRIPTION
## Summary

- stop the web canvas wrapper from silently changing its drawing-buffer dimensions on every window resize
- preserve initial DPR-aware sizing through the existing `MakeWebGPUCanvasContext` path
- leave subsequent buffer resizing to the renderer/app so dependent depth and MSAA attachments can be recreated atomically

Fixes #351.

## Root cause

The wrapper listened to `window.resize` and changed `canvas.width` / `canvas.height` after a 100 ms debounce. WebGPU canvas resizing invalidates the current texture, but renderers such as Three.js still owned depth/MSAA attachments at the previous dimensions. The next render pass therefore mixed textures of different extents and failed validation every frame.

The browser regression reproduced the current issue exactly: resizing the example viewport changed the drawing buffer from 2400×1344 to 1800×744 while Three.js kept its 2400×1344 depth attachment.

## Verification

- Current `main` RED: Three.js InstancedMesh emits repeated attachment-size validation warnings after a 1200×800 → 900×500 viewport resize.
- Patched GREEN:
  - CSS canvas size changes from 1200×672 to 900×372.
  - Drawing buffer remains 2400×1344 until the renderer explicitly resizes it.
  - Zero attachment-size warnings.
  - The scene continues rendering after resize.
- `tsc -p packages/webgpu/tsconfig.json --noEmit`
- targeted ESLint and Prettier checks
- `yarn workspace react-native-webgpu build`
- root `yarn tsc`: 3/3 workspaces pass
- `git diff --check`

The example asset hook was temporarily bypassed only for browser setup because the current web example cannot resolve its Metro asset IDs; that harness change was fully reverted and is not part of this PR.