### PR TITLE
Fix/implicit device synchronization

### DIFF
--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -48,6 +48,7 @@ import { SharedTextureMemory } from "./SharedTextureMemory";
 import { ImportExternalTexture } from "./ImportExternalTexture";
 import { VisionCamera } from "./VisionCamera";
 import { SixteenBitTextures } from "./SixteenBitTextures";
+import { CrossRuntimeDevice } from "./Diagnostics/CrossRuntimeDevice";
 
 // The two lines below are needed by three.js
 import "fast-text-encoding";
@@ -126,6 +127,10 @@ function App() {
           />
           <Stack.Screen name="BackgroundDetach" component={BackgroundDetach} />
           <Stack.Screen name="SurfaceChurn" component={SurfaceChurn} />
+          <Stack.Screen
+            name="CrossRuntimeDevice"
+            component={CrossRuntimeDevice}
+          />
           <Stack.Screen
             name="StorageBufferVertices"
             component={StorageBufferVertices}

--- a/apps/example/src/Diagnostics/CrossRuntimeDevice.tsx
+++ b/apps/example/src/Diagnostics/CrossRuntimeDevice.tsx
@@ -1,0 +1,404 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Button,
+  Platform,
+  ScrollView,
+  Settings,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import type { CanvasRef, RNCanvasContext } from "react-native-webgpu";
+import { Canvas, installWebGPU } from "react-native-webgpu";
+import { runOnUI, useSharedValue } from "react-native-reanimated";
+import type { SharedValue } from "react-native-reanimated";
+
+const MODES = [
+  "write",
+  "submit",
+  "create",
+  "map",
+  "present",
+  "churn",
+  "destroy",
+  "all",
+] as const;
+
+type ReproMode = (typeof MODES)[number];
+
+const MODE_SETTING = "RNWebGPUCrossRuntimeMode";
+
+const OPS_PER_FRAME = 32;
+const OPS_PER_TICK = 32;
+const SURFACE_CHURN_INTERVAL_MS = 150;
+const DESTROY_AFTER_MS = 2_000;
+
+interface Shared {
+  device: GPUDevice;
+  format: GPUTextureFormat;
+  uiBuffer: GPUBuffer;
+  jsBuffer: GPUBuffer;
+}
+
+const readInitialMode = (): ReproMode => {
+  if (Platform.OS !== "ios") {
+    return "write";
+  }
+  const stored = Settings.get(MODE_SETTING);
+  return MODES.includes(stored) ? (stored as ReproMode) : "write";
+};
+
+const renderOnUI = (
+  running: SharedValue<boolean>,
+  uiFrames: SharedValue<number>,
+  device: GPUDevice,
+  context: RNCanvasContext,
+  buffer: GPUBuffer,
+  format: GPUTextureFormat,
+  mode: ReproMode,
+  ops: number,
+) => {
+  "worklet";
+
+  installWebGPU();
+  context.configure({ device, format, alphaMode: "premultiplied" });
+
+  const data = new Float32Array(4);
+  let frameNumber = 0;
+
+  const stress = () => {
+    if (mode === "write" || mode === "all") {
+      for (let i = 0; i < ops; i += 1) {
+        data[1] = i;
+        device.queue.writeBuffer(buffer, 0, data);
+      }
+    }
+    if (mode === "submit" || mode === "all") {
+      for (let i = 0; i < ops; i += 1) {
+        device.queue.submit([device.createCommandEncoder().finish()]);
+      }
+    }
+    if (mode === "create" || mode === "all") {
+      for (let i = 0; i < ops; i += 1) {
+        const scratch = device.createBuffer({
+          size: 256,
+          usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM,
+        });
+        scratch.destroy();
+      }
+    }
+  };
+
+  const frame = () => {
+    if (!running.value) {
+      return;
+    }
+    frameNumber += 1;
+    uiFrames.value = frameNumber;
+    data[0] = frameNumber;
+    stress();
+
+    const encoder = device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: context.getCurrentTexture().createView(),
+          clearValue: [
+            0.5 + 0.5 * Math.sin(frameNumber / 29),
+            0.5 + 0.5 * Math.sin(frameNumber / 31 + 2),
+            0.5 + 0.5 * Math.sin(frameNumber / 37 + 4),
+            1,
+          ],
+          loadOp: "clear",
+          storeOp: "store",
+        },
+      ],
+    });
+    pass.end();
+    device.queue.submit([encoder.finish()]);
+    context.present();
+
+    requestAnimationFrame(frame);
+  };
+
+  frame();
+};
+
+const RenderCanvas = ({
+  shared,
+  mode,
+  uiFrames,
+}: {
+  shared: Shared;
+  mode: ReproMode;
+  uiFrames: SharedValue<number>;
+}) => {
+  const ref = useRef<CanvasRef>(null);
+  const running = useSharedValue(true);
+
+  useEffect(() => {
+    const context = ref.current?.getContext("webgpu");
+    if (!context) {
+      throw new Error("Failed to create the WebGPU canvas context");
+    }
+    running.value = true;
+    runOnUI(renderOnUI)(
+      running,
+      uiFrames,
+      shared.device,
+      context,
+      shared.uiBuffer,
+      shared.format,
+      mode,
+      mode === "present" || mode === "churn" ? 0 : OPS_PER_FRAME,
+    );
+    return () => {
+      running.value = false;
+    };
+  }, [shared, running, mode, uiFrames]);
+
+  return <Canvas ref={ref} style={styles.canvas} />;
+};
+
+const ChurnCanvas = ({ shared }: { shared: Shared }) => {
+  const ref = useRef<CanvasRef>(null);
+
+  useEffect(() => {
+    const context = ref.current?.getContext("webgpu");
+    if (!context) {
+      return;
+    }
+    context.configure({
+      device: shared.device,
+      format: shared.format,
+      alphaMode: "premultiplied",
+    });
+    const encoder = shared.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: context.getCurrentTexture().createView(),
+          clearValue: [1, 0, 1, 1],
+          loadOp: "clear",
+          storeOp: "store",
+        },
+      ],
+    });
+    pass.end();
+    shared.device.queue.submit([encoder.finish()]);
+    context.present();
+  }, [shared]);
+
+  return <Canvas ref={ref} style={styles.churn} />;
+};
+
+export const CrossRuntimeDevice = () => {
+  const [mode, setMode] = useState<ReproMode>(readInitialMode);
+  const [shared, setShared] = useState<Shared | null>(null);
+  const [churnEpoch, setChurnEpoch] = useState(0);
+  const [ticks, setTicks] = useState(0);
+  const [uiFrameCount, setUiFrameCount] = useState(0);
+  const uiFrames = useSharedValue(0);
+  const jsTicks = useRef(0);
+
+  useEffect(() => {
+    if (Platform.OS === "ios") {
+      Settings.set({ [MODE_SETTING]: mode });
+    }
+  }, [mode]);
+
+  useEffect(() => {
+    let live = true;
+    let created: Shared | null = null;
+
+    (async () => {
+      installWebGPU();
+      const adapter = await navigator.gpu.requestAdapter();
+      if (!adapter) {
+        throw new Error("No WebGPU adapter");
+      }
+      const device = await adapter.requestDevice();
+      const makeBuffer = (label: string) =>
+        device.createBuffer({
+          label,
+          size: 16,
+          usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM,
+        });
+      created = {
+        device,
+        format: navigator.gpu.getPreferredCanvasFormat(),
+        uiBuffer: makeBuffer("ui-runtime uniform"),
+        jsBuffer: makeBuffer("js-runtime uniform"),
+      };
+      device.lost.then((info) => {
+        console.error(`[cross-runtime] device lost: ${info.message}`);
+      });
+      if (live) {
+        console.log(`[cross-runtime] mode=${mode}`);
+        setShared(created);
+      }
+    })().catch((error) => {
+      console.error(`[cross-runtime] setup failed: ${error}`);
+    });
+
+    return () => {
+      live = false;
+      created?.device.destroy();
+    };
+  }, [mode]);
+
+  useEffect(() => {
+    if (shared === null || mode === "churn") {
+      return undefined;
+    }
+    let live = true;
+    const data = new Float32Array(4);
+    let tick = 0;
+
+    const pump = () => {
+      if (!live) {
+        return;
+      }
+      tick += 1;
+      data[0] = tick;
+      const { device } = shared;
+
+      if (mode === "write" || mode === "all") {
+        for (let i = 0; i < OPS_PER_TICK; i += 1) {
+          data[1] = i;
+          device.queue.writeBuffer(shared.jsBuffer, 0, data);
+        }
+      }
+      if (mode === "submit" || mode === "present" || mode === "all") {
+        for (let i = 0; i < OPS_PER_TICK; i += 1) {
+          device.queue.submit([device.createCommandEncoder().finish()]);
+        }
+      }
+      if (mode === "create" || mode === "all") {
+        for (let i = 0; i < OPS_PER_TICK; i += 1) {
+          const texture = device.createTexture({
+            size: [8, 8],
+            format: "rgba8unorm",
+            usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+          });
+          texture.destroy();
+        }
+      }
+      if (mode === "map" || mode === "all") {
+        const staging = device.createBuffer({
+          size: 256,
+          usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC,
+        });
+        staging
+          .mapAsync(GPUMapMode.WRITE)
+          .then(() => {
+            new Float32Array(staging.getMappedRange())[0] = tick;
+            staging.unmap();
+            staging.destroy();
+          })
+          .catch(() => {
+            staging.destroy();
+          });
+        device.queue.onSubmittedWorkDone().catch(() => {});
+      }
+
+      jsTicks.current = tick;
+      if (tick % 60 === 0) {
+        setTicks(tick);
+      }
+      setTimeout(pump, 0);
+    };
+
+    pump();
+    return () => {
+      live = false;
+    };
+  }, [shared, mode]);
+
+  useEffect(() => {
+    if (shared === null || (mode !== "churn" && mode !== "all")) {
+      return undefined;
+    }
+    const interval = setInterval(
+      () => setChurnEpoch((value) => value + 1),
+      SURFACE_CHURN_INTERVAL_MS,
+    );
+    return () => clearInterval(interval);
+  }, [shared, mode]);
+
+  useEffect(() => {
+    if (shared === null || mode !== "destroy") {
+      return undefined;
+    }
+    const timeout = setTimeout(() => {
+      console.log(
+        "[cross-runtime] destroying device while the UI runtime renders",
+      );
+      shared.device.destroy();
+    }, DESTROY_AFTER_MS);
+    return () => clearTimeout(timeout);
+  }, [shared, mode]);
+
+  useEffect(() => {
+    const interval = setInterval(() => setUiFrameCount(uiFrames.value), 500);
+    return () => clearInterval(interval);
+  }, [uiFrames]);
+
+  const chooseMode = useCallback((next: ReproMode) => {
+    setShared(null);
+    setMode(next);
+  }, []);
+
+  const showChurn = mode === "churn" || mode === "all";
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.instructions}>
+        <Text style={styles.title}>Cross-runtime device stress</Text>
+        <Text selectable style={styles.copy}>
+          mode: {mode} ui: {uiFrameCount} js: {ticks}
+        </Text>
+        <ScrollView horizontal contentContainerStyle={styles.buttons}>
+          {MODES.map((value) => (
+            <Button
+              key={value}
+              title={value}
+              onPress={() => chooseMode(value)}
+            />
+          ))}
+        </ScrollView>
+      </View>
+      {shared ? (
+        <View style={styles.canvasHost}>
+          <RenderCanvas shared={shared} mode={mode} uiFrames={uiFrames} />
+          {showChurn ? <ChurnCanvas key={churnEpoch} shared={shared} /> : null}
+        </View>
+      ) : (
+        <View style={styles.canvas} />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "black" },
+  instructions: {
+    paddingHorizontal: 16,
+    paddingTop: 64,
+    paddingBottom: 12,
+    gap: 8,
+    backgroundColor: "white",
+  },
+  title: { fontSize: 18, fontWeight: "600" },
+  copy: { fontSize: 12 },
+  buttons: { gap: 8, alignItems: "center" },
+  canvasHost: { flex: 1 },
+  canvas: { flex: 1 },
+  churn: {
+    position: "absolute",
+    right: 12,
+    bottom: 12,
+    width: 96,
+    height: 96,
+  },
+});

--- a/apps/example/src/Diagnostics/CrossRuntimeDevice.tsx
+++ b/apps/example/src/Diagnostics/CrossRuntimeDevice.tsx
@@ -209,7 +209,6 @@ export const CrossRuntimeDevice = () => {
 
   useEffect(() => {
     let live = true;
-    let created: Shared | null = null;
 
     (async () => {
       installWebGPU();
@@ -224,7 +223,7 @@ export const CrossRuntimeDevice = () => {
           size: 16,
           usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM,
         });
-      created = {
+      const created: Shared = {
         device,
         format: navigator.gpu.getPreferredCanvasFormat(),
         uiBuffer: makeBuffer("ui-runtime uniform"),
@@ -241,9 +240,11 @@ export const CrossRuntimeDevice = () => {
       console.error(`[cross-runtime] setup failed: ${error}`);
     });
 
+    // The device is deliberately left alive on mode change: destroying it here
+    // trips a separate teardown crash on Android (FencedDeleter null-deref in
+    // Surface::~Surface) that has nothing to do with the cross-runtime race.
     return () => {
       live = false;
-      created?.device.destroy();
     };
   }, [mode]);
 

--- a/apps/example/src/Diagnostics/DiagnosticsList.tsx
+++ b/apps/example/src/Diagnostics/DiagnosticsList.tsx
@@ -41,6 +41,10 @@ const tests = [
     screen: "SurfaceChurn",
     title: "⚠️ Surface Churn",
   },
+  {
+    screen: "CrossRuntimeDevice",
+    title: "⚠️ Cross-Runtime Device Stress",
+  },
 ] as const;
 
 export const DiagnosticsList = () => {

--- a/apps/example/src/Route.ts
+++ b/apps/example/src/Route.ts
@@ -36,6 +36,7 @@ export type Routes = {
   RenderAfterUnmount: undefined;
   BackgroundDetach: undefined;
   SurfaceChurn: undefined;
+  CrossRuntimeDevice: undefined;
   StorageBufferVertices: undefined;
   SharedTextureMemory: undefined;
   ImportExternalTexture: undefined;

--- a/packages/webgpu/cpp/rnwgpu/api/GPUAdapter.cpp
+++ b/packages/webgpu/cpp/rnwgpu/api/GPUAdapter.cpp
@@ -66,6 +66,33 @@ async::AsyncTaskHandle GPUAdapter::requestDevice(
     }
   }
 
+  // A GPUDevice is reachable from every JS runtime it is boxed into (main JS,
+  // Reanimated UI, worklet runtimes) and from SurfaceInfo, so Dawn's public
+  // methods must be safe to call from several threads at once. Without this
+  // feature DeviceBase::mMutex is null and every device->GetGuard() inside
+  // Dawn is a no-op.
+  bool injectedImplicitSync = false;
+  {
+    const auto sync = wgpu::FeatureName::ImplicitDeviceSynchronization;
+    wgpu::SupportedFeatures supported;
+    _instance.GetFeatures(&supported);
+    const auto *end = supported.features + supported.featureCount;
+    if (std::find(supported.features, end, sync) != end) {
+      if (!descriptor.has_value()) {
+        descriptor = std::make_shared<GPUDeviceDescriptor>();
+      }
+      auto &desc = descriptor.value();
+      if (!desc->requiredFeatures.has_value()) {
+        desc->requiredFeatures = std::vector<wgpu::FeatureName>{};
+      }
+      auto &features = desc->requiredFeatures.value();
+      if (std::find(features.begin(), features.end(), sync) == features.end()) {
+        features.push_back(sync);
+        injectedImplicitSync = true;
+      }
+    }
+  }
+
   wgpu::DeviceDescriptor aDescriptor;
   Convertor conv;
   if (!conv(aDescriptor, descriptor)) {
@@ -144,7 +171,7 @@ async::AsyncTaskHandle GPUAdapter::requestDevice(
       async::RuntimeContext::getOrCreate(runtime, _async->instance());
   return context->postTask(
       [this, aDescriptor, descriptor, label = std::move(label),
-       deviceLostBinding, context,
+       deviceLostBinding, context, injectedImplicitSync,
        creationRuntime](const async::AsyncTaskHandle::ResolveFunction &resolve,
                         const async::AsyncTaskHandle::RejectFunction &reject) {
         // Build a local mutable copy so we can chain Dawn's device toggles.
@@ -201,7 +228,8 @@ async::AsyncTaskHandle GPUAdapter::requestDevice(
         _instance.RequestDevice(
             &deviceDesc, wgpu::CallbackMode::AllowProcessEvents,
             [context, resolve, reject, label, creationRuntime,
-             deviceLostBinding](wgpu::RequestDeviceStatus status,
+             deviceLostBinding,
+             injectedImplicitSync](wgpu::RequestDeviceStatus status,
                                 wgpu::Device device, wgpu::StringView message) {
               if (message.length) {
                 fprintf(stderr, "%s", message.data);
@@ -250,6 +278,7 @@ async::AsyncTaskHandle GPUAdapter::requestDevice(
 
               auto deviceHost = std::make_shared<GPUDevice>(std::move(device),
                                                             context, label);
+              deviceHost->setHidesImplicitSync(injectedImplicitSync);
               *deviceLostBinding = deviceHost;
 
               // Register the device in the static registry so the uncaptured

--- a/packages/webgpu/cpp/rnwgpu/api/GPUDevice.cpp
+++ b/packages/webgpu/cpp/rnwgpu/api/GPUDevice.cpp
@@ -568,6 +568,10 @@ std::unordered_set<std::string> GPUDevice::getFeatures() {
   for (size_t i = 0; i < supportedFeatures.featureCount; ++i) {
     auto feature = supportedFeatures.features[i];
     enabled.insert(feature);
+    if (_hidesImplicitSync &&
+        feature == wgpu::FeatureName::ImplicitDeviceSynchronization) {
+      continue;
+    }
     std::string name;
     convertEnumToJSUnion(feature, &name);
     result.insert(name);

--- a/packages/webgpu/cpp/rnwgpu/api/GPUDevice.h
+++ b/packages/webgpu/cpp/rnwgpu/api/GPUDevice.h
@@ -162,6 +162,10 @@ public:
   void addEventListener(std::string type, jsi::Function callback);
   void removeEventListener(std::string type, jsi::Function callback);
 
+  // True when requestDevice() added ImplicitDeviceSynchronization itself; the
+  // caller never asked for it, so it stays out of device.features.
+  void setHidesImplicitSync(bool value) { _hidesImplicitSync = value; }
+
   std::string getLabel() { return _label; }
   void setLabel(const std::string &label) {
     _label = label;
@@ -285,6 +289,7 @@ private:
   wgpu::Device _instance;
   std::shared_ptr<async::RuntimeContext> _async;
   std::string _label;
+  bool _hidesImplicitSync = false;
   // Guards the device-lost state below. getLost() runs on a JS thread, but
   // Dawn's AllowSpontaneous device-lost callback (and device destruction) can
   // fire notifyDeviceLost() from other threads, so the mutex keeps these


### PR DESCRIPTION
Fixes #455.

## Why it crashes

`GPUAdapter::requestDevice` never asks for Dawn's `ImplicitDeviceSynchronization`, so `DeviceBase::mMutex` stays null (`Device.cpp:449`) and every `device->GetGuard()` inside Dawn turns into a no-op. Meanwhile rnwgpu hands the same device to every runtime it is boxed into (`installWebGPU`, GPUQueue through the Worklets serializer) and drives it from `SurfaceInfo` as well. Two threads then walk Dawn's queue, uploader and tick state at once, and Metal or Vulkan falls over a few seconds later.

## The change

`requestDevice` requests the feature when the adapter advertises it. Dawn's generated entry points then take `device->GetGuard()` (see the `ProcTable.cpp` template), and the paths a hand-rolled queue lock would miss guard themselves: `DeviceBase::APITick` (`Device.cpp:1589`), `Surface::Configure` / `GetCurrentTexture` / `Present` (`Surface.cpp:495,577,634`), and `metal::WaitForCommandsToBeScheduled` (`MetalBackend.mm:41`). Command encoding stays unlocked by Dawn's design, which matches one encoder per thread.

This is the supported way to use one device from several threads, and the same mechanism Chrome relies on. Single-runtime apps pay an uncontended mutex per call. Two runtimes serialize exactly when they would otherwise corrupt each other.

`GPUDevice::getFeatures` hides the feature when rnwgpu added it, so `device.features` keeps mirroring what the caller asked for. An explicit request still shows up, which is what `FeatureNames.spec.ts` asserts.

The other two commits add the diagnostic screen from the issue, under Diagnostics -> "Cross-Runtime Device Stress".

## Verification

iPhone 17 Pro simulator, iOS 26.5, Debug with ASan, 30 seconds per mode:

| mode | before | after |
|---|---|---|
| write | crash 12s | pass |
| submit | crash 6s | pass |
| create | pass | pass |
| map | crash 4s | pass |
| present | crash 4s | pass |
| churn | pass | pass |
| destroy | pass | pass |
| all | crash 6s | pass |

- 180 second soaks on `all` and `map`, frame and tick counters still climbing, so nothing deadlocks.
- Android emulator (API 36, arm64): `submit` crashed on the JS thread in `createBuffer` before, all seven modes run clean after.
- `yarn test` (jest e2e against the running app): 174/174.
- Reanimated examples (UI Thread, Dedicated Thread, Async Buffer UI) render as before.
- Throughput over 45 seconds of `write` is unchanged: ui 2971 / js 2940, against ui 2923 / js 2880 for a hand-rolled per-queue lock I benchmarked against.

## Alternative

A per-native-queue `std::mutex` in rnwgpu around the GPUQueue and SurfaceInfo entry points fixes 7 of the 8 modes. `map` still aborts, because `RuntimeContext::tick()` calls `Instance::ProcessEvents()` from every runtime and `DeviceBase::APITick` relies on `GetGuard()`. Covering that by hand means repeating the lock at every Dawn entry point two runtimes can reach.