### PR TITLE
fix(💥): detach swapchains before destroying the device (fixes Android Canvas unmount crash)

### DIFF
--- a/apps/example/src/Diagnostics/ContextEdgeCases.tsx
+++ b/apps/example/src/Diagnostics/ContextEdgeCases.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { Button, ScrollView, Text, View } from "react-native";
 import type { CanvasRef } from "react-native-webgpu";
 import { Canvas } from "react-native-webgpu";
@@ -29,11 +29,57 @@ import {
 //    the context keeps handing out textures as if still configured, where the
 //    spec says the canvas should behave as if it was never configured.
 //
+// 4. device.destroy() on the device a mounted Canvas is configured with.
+//    Dawn's Vulkan backend cannot detach a swapchain after its device was
+//    destroyed, so the Canvas unmount crashed on Android. Per spec the canvas
+//    stays configured (getCurrentTexture() must not throw) and configure()
+//    with a replacement device must render on screen again; the unmount
+//    toggle then checks the swapchain teardown. "unconfigure() first" covers
+//    the idiomatic cleanup order, where Dawn parks the old swapchain in the
+//    surface for reuse instead of detaching it.
+//
 // Each button is an independent repro; on a broken build the first two
 // terminate the app, so relaunch between attempts.
 export const ContextEdgeCases = () => {
   const ref = useRef<CanvasRef>(null);
   const { log, append } = useDiagnosticLog();
+  const [mounted, setMounted] = useState(true);
+
+  const destroyDevice = async (unconfigureFirst: boolean) => {
+    try {
+      const { device, format } = await initGPU(append);
+      const ctx = ref.current!.getContext("webgpu")!;
+      ctx.configure({ device, format, alphaMode: "opaque" });
+      drawClearFrame(device, ctx, 0);
+      if (unconfigureFirst) {
+        append("rendered one frame, calling unconfigure()...");
+        ctx.unconfigure();
+      } else {
+        append("rendered one frame");
+      }
+      append("calling device.destroy()...");
+      device.destroy();
+      if (!unconfigureFirst) {
+        const texture = ctx.getCurrentTexture();
+        append(
+          `getCurrentTexture() after destroy() -> ${texture.width}x${texture.height} (spec: invalid texture, no throw)`,
+        );
+        ctx.present();
+      }
+      const replacement = await initGPU(append);
+      ctx.configure({
+        device: replacement.device,
+        format: replacement.format,
+        alphaMode: "opaque",
+      });
+      drawClearFrame(replacement.device, ctx, 30);
+      append(
+        "reconfigured with a new device and rendered: the canvas should show a new color. Now unmount the canvas.",
+      );
+    } catch (e) {
+      append(`threw: ${e}`);
+    }
+  };
 
   const getCurrentTextureUnconfigured = () => {
     try {
@@ -99,8 +145,20 @@ export const ContextEdgeCases = () => {
           title="unconfigure() then getCurrentTexture()"
           onPress={unconfigureStub}
         />
+        <Button
+          title="device.destroy() then reconfigure"
+          onPress={() => destroyDevice(false)}
+        />
+        <Button
+          title="unconfigure(), device.destroy(), reconfigure"
+          onPress={() => destroyDevice(true)}
+        />
+        <Button
+          title={mounted ? "unmount canvas" : "mount canvas"}
+          onPress={() => setMounted((m) => !m)}
+        />
       </View>
-      <Canvas ref={ref} style={diagnosticStyles.canvas} />
+      {mounted && <Canvas ref={ref} style={diagnosticStyles.canvas} />}
       <ScrollView style={diagnosticStyles.log}>
         {log.map((line, i) => (
           <Text key={i} style={diagnosticStyles.logLine}>

--- a/packages/webgpu/android/cpp/cpp-adapter.cpp
+++ b/packages/webgpu/android/cpp/cpp-adapter.cpp
@@ -25,7 +25,8 @@ extern "C" JNIEXPORT void JNICALL Java_com_webgpu_WebGPUModule_initializeNative(
   auto jsCallInvoker{
       facebook::jni::alias_ref<facebook::react::CallInvokerHolder::javaobject>{
           reinterpret_cast<facebook::react::CallInvokerHolder::javaobject>(
-              jsCallInvokerHolder)} -> cthis()->getCallInvoker()};
+              jsCallInvokerHolder)} -> cthis()
+          ->getCallInvoker()};
   auto platformContext =
       std::make_shared<rnwgpu::AndroidPlatformContext>(globalBlobModule);
   manager = std::make_shared<rnwgpu::RNWebGPUManager>(runtime, jsCallInvoker,
@@ -55,13 +56,19 @@ extern "C" JNIEXPORT void JNICALL Java_com_webgpu_WebGPUView_onSurfaceCreate(
   }
   auto &registry = rnwgpu::SurfaceRegistry::getInstance();
   auto gpu = manager->_gpu;
-  auto surface = manager->_platformContext->makeSurface(
-      gpu, window, static_cast<int>(width), static_cast<int>(height));
+  // SurfaceInfo creates the Dawn surface now and keeps the factory so it can
+  // rebuild one for the same window later (device destroyed, then the canvas
+  // reconfigured with a replacement device).
+  auto platformContext = manager->_platformContext;
+  int w = static_cast<int>(width);
+  int h = static_cast<int>(height);
+  auto makeSurface = [platformContext, gpu, w, h](void *nativeWindow) {
+    return platformContext->makeSurface(gpu, nativeWindow, w, h);
+  };
   // Find-or-create + attach runs atomically under the registry lock so a
   // concurrent destroyContext cannot orphan this surface.
   auto info = registry.attachSurface(
-      contextId, gpu, static_cast<int>(width), static_cast<int>(height), window,
-      surface, [](void *nativeSurface) {
+      contextId, gpu, w, h, window, makeSurface, [](void *nativeSurface) {
         ANativeWindow_release(static_cast<ANativeWindow *>(nativeSurface));
       });
   // The attach is adopted at the next frame boundary by the rendering thread;

--- a/packages/webgpu/apple/MetalView.mm
+++ b/packages/webgpu/apple/MetalView.mm
@@ -33,13 +33,20 @@
   void *nativeSurface = (void *)CFBridgingRetain(self.layer);
   auto &registry = rnwgpu::SurfaceRegistry::getInstance();
   auto gpu = manager->_gpu;
-  auto surface = manager->_platformContext->makeSurface(
-      gpu, nativeSurface, size.width, size.height);
+  // SurfaceInfo creates the Dawn surface now and keeps the factory so it can
+  // rebuild one for the same layer later (device destroyed, then the canvas
+  // reconfigured with a replacement device).
+  auto platformContext = manager->_platformContext;
+  int width = size.width;
+  int height = size.height;
+  auto makeSurface = [platformContext, gpu, width, height](void *layer) {
+    return platformContext->makeSurface(gpu, layer, width, height);
+  };
   // Find-or-create + attach runs atomically under the registry lock so a
   // concurrent destroyContext cannot orphan this surface.
   auto info = registry.attachSurface(
       [_contextId intValue], gpu, size.width, size.height, nativeSurface,
-      surface, [](void *layer) {
+      makeSurface, [](void *layer) {
         // The releaser can run on the rendering thread; CALayer teardown
         // belongs on the main thread.
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/packages/webgpu/cpp/rnwgpu/SurfaceRegistry.h
+++ b/packages/webgpu/cpp/rnwgpu/SurfaceRegistry.h
@@ -270,6 +270,30 @@ public:
     _frameEpoch++;
   }
 
+  // Detach this surface's swapchain when it is bound to `device`, called from
+  // GPUDevice::destroy() before the device is torn down. Releasing the Dawn
+  // surface here runs ~Surface -> SwapChain::DetachFromSurface while the
+  // device still owns its FencedDeleter. Left to the native view teardown
+  // (SurfaceInfo::detach, one frame later) the device is already destroyed and
+  // Dawn dereferences a freed FencedDeleter -> SIGSEGV on the Vulkan backend.
+  // The native window pointer stays in _nativeSurface so detach() still
+  // returns it to the platform.
+  void unconfigureIfDevice(const wgpu::Device &device) {
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+    if (_config.device == nullptr || _config.device.Get() != device.Get()) {
+      return;
+    }
+    if (_surface) {
+      _surface.Unconfigure();
+      _surface = nullptr;
+      _acquiredFromSurface = false;
+    }
+    _texture = nullptr;
+    _config = {};
+    _viewFormats.clear();
+    _frameEpoch++;
+  }
+
   bool isConfigured() {
     std::shared_lock<std::shared_mutex> lock(_mutex);
     return _config.device != nullptr;
@@ -585,6 +609,15 @@ public:
   void clear() {
     std::unique_lock<std::shared_mutex> lock(_mutex);
     _registry.clear();
+  }
+
+  // Detach every surface configured with `device` before it is destroyed.
+  // Lock order is registry -> SurfaceInfo, matching every other path.
+  void unconfigureDevice(const wgpu::Device &device) {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    for (auto &entry : _registry) {
+      entry.second->unconfigureIfDevice(device);
+    }
   }
 
 private:

--- a/packages/webgpu/cpp/rnwgpu/SurfaceRegistry.h
+++ b/packages/webgpu/cpp/rnwgpu/SurfaceRegistry.h
@@ -44,6 +44,12 @@ struct Size {
 // CAMetalLayer on Apple platforms). May run on any thread.
 using NativeSurfaceReleaser = std::function<void(void *)>;
 
+// Creates a Dawn surface for the platform's native surface pointer. Kept for
+// as long as the native surface is attached so the Dawn surface can be
+// rebuilt after it had to be dropped (see unconfigureIfDevice). May run on
+// the UI thread (attach) or the rendering thread (configure).
+using SurfaceFactory = std::function<wgpu::Surface(void *)>;
+
 // Bridges the asynchronous native surface lifecycle (surfaces appear and
 // disappear on the platform UI thread) with the synchronous WebGPU canvas API
 // (the JS render loop must always be able to acquire a texture).
@@ -81,6 +87,7 @@ public:
   ~SurfaceInfo() {
     // Drop the Dawn objects before releasing the native surfaces they borrow.
     _surface = nullptr;
+    _surfaceDevice = nullptr;
     _pendingSurface = nullptr;
     _texture = nullptr;
     if (_pendingReleaser && _pendingNativeSurface) {
@@ -97,8 +104,11 @@ public:
   // frame boundary (applyPendingAttach); callers should follow up with
   // RNWebGPUManager::flushPendingSurfaceTransition so contexts that are not
   // currently rendering also pick it up.
-  void attachSurface(void *nativeSurface, wgpu::Surface surface,
+  void attachSurface(void *nativeSurface, SurfaceFactory makeSurface,
                      NativeSurfaceReleaser releaser) {
+    // Dawn surface creation only wraps the native handle (the swapchain is
+    // created at Configure), so it is cheap enough to do eagerly here.
+    wgpu::Surface surface = makeSurface ? makeSurface(nativeSurface) : nullptr;
     void *replacedSurface = nullptr;
     NativeSurfaceReleaser replacedReleaser;
     {
@@ -111,6 +121,7 @@ public:
       _hasPendingAttach = true;
       _pendingNativeSurface = nativeSurface;
       _pendingSurface = std::move(surface);
+      _pendingSurfaceFactory = std::move(makeSurface);
       _pendingReleaser = std::move(releaser);
     }
     if (replacedReleaser && replacedSurface) {
@@ -169,7 +180,11 @@ public:
       // can be null if surface creation failed).
       replacedSurface = _nativeSurface;
       replacedReleaser = std::move(_releaser);
+      // Dropping the previous Dawn surface (if any) detaches its swapchain;
+      // _surfaceDevice kept that device alive for exactly this.
       _surface = std::move(_pendingSurface);
+      _surfaceDevice = nullptr;
+      _surfaceFactory = std::move(_pendingSurfaceFactory);
       _nativeSurface = _pendingNativeSurface;
       _releaser = std::move(_pendingReleaser);
       _hasPendingAttach = false;
@@ -187,10 +202,7 @@ public:
         if (blit) {
           config.usage |= wgpu::TextureUsage::CopyDst;
         }
-        _surface.Configure(&config);
-#ifdef __APPLE__
-        applyCAMetalLayerColorSpace(_nativeSurface, _config.format);
-#endif
+        configureSurfaceLocked(config);
         if (blit) {
           presentBlit = blitOffscreenToSurfaceLocked();
           device = _config.device;
@@ -242,6 +254,14 @@ public:
     _config.presentMode = wgpu::PresentMode::Fifo;
     _texture = nullptr;
     _frameEpoch++;
+    // The Dawn surface is dropped when its device is destroyed
+    // (unconfigureIfDevice) while the native window stays attached; a
+    // configure() with a replacement device is the standard recovery, so
+    // rebuild it here rather than rendering offscreen until the next attach.
+    if (!_surface && _nativeSurface && _surfaceFactory) {
+      _surface = _surfaceFactory(_nativeSurface);
+      _surfaceDevice = nullptr;
+    }
     _configureLocked();
   }
 
@@ -270,27 +290,36 @@ public:
     _frameEpoch++;
   }
 
-  // Detach this surface's swapchain when it is bound to `device`, called from
-  // GPUDevice::destroy() before the device is torn down. Releasing the Dawn
-  // surface here runs ~Surface -> SwapChain::DetachFromSurface while the
-  // device still owns its FencedDeleter. Left to the native view teardown
-  // (SurfaceInfo::detach, one frame later) the device is already destroyed and
-  // Dawn dereferences a freed FencedDeleter -> SIGSEGV on the Vulkan backend.
-  // The native window pointer stays in _nativeSurface so detach() still
-  // returns it to the platform.
+  // Called by GPUDevice::destroy() for every canvas before the device is torn
+  // down. Workaround for a Dawn Vulkan bug: SwapChainVk::DetachFromSurfaceImpl
+  // (SwapChainVk.cpp) dereferences the device's FencedDeleter, which
+  // DeviceVk::DestroyImpl has already nulled, so a ~Surface that runs after
+  // the device was destroyed (the native view teardown in detach(), or the
+  // Canvas unmount one frame later) SIGSEGVs. Metal only destroys the
+  // drawable texture and tolerates the order. Invariant this maintains: no
+  // Dawn surface carries a swapchain bound to `device` once destroy() runs.
+  // Removable once Dawn guards DetachFromSurfaceImpl against a destroyed
+  // device.
+  //
+  // The match is on _surfaceDevice, not only on _config.device: unconfigure()
+  // does not detach the swapchain, Dawn parks it in the surface for reuse by
+  // the next Configure (Surface::Unconfigure), so the spec-idiomatic
+  // `context.unconfigure(); device.destroy();` order leaves a swapchain bound
+  // to the destroyed device behind an unconfigured canvas.
+  //
+  // _config is kept: per spec a canvas whose device was destroyed stays
+  // configured and hands out invalid textures, so a render loop that ticks
+  // once more after destroy() no-ops instead of throwing "not configured".
+  // The native window and its factory stay too, so configure() with a
+  // replacement device rebuilds the surface.
   void unconfigureIfDevice(const wgpu::Device &device) {
     std::unique_lock<std::shared_mutex> lock(_mutex);
-    if (_config.device == nullptr || _config.device.Get() != device.Get()) {
+    if (!isDeviceLocked(_config.device, device) &&
+        !isDeviceLocked(_surfaceDevice, device)) {
       return;
     }
-    if (_surface) {
-      _surface.Unconfigure();
-      _surface = nullptr;
-      _acquiredFromSurface = false;
-    }
+    dropSurfaceLocked();
     _texture = nullptr;
-    _config = {};
-    _viewFormats.clear();
     _frameEpoch++;
   }
 
@@ -403,20 +432,16 @@ private:
         releasers[0] = std::move(_pendingReleaser);
         _pendingNativeSurface = nullptr;
       }
-      if (_surface) {
-        if (createFallbackTexture && _config.device != nullptr) {
-          _texture = createOffscreenTextureLocked();
-        }
-        _surface = nullptr;
-        // The in-flight frame (if any) rendered into the destroyed surface;
-        // presentFrame() must not present it.
-        _acquiredFromSurface = false;
+      if (_surface && createFallbackTexture && _config.device != nullptr) {
+        _texture = createOffscreenTextureLocked();
       }
+      dropSurfaceLocked();
       _frameEpoch++;
       // Window ownership is independent of the Dawn surface handle (which can
       // be null if surface creation failed): always return the window.
       releasedSurfaces[1] = _nativeSurface;
       releasers[1] = std::move(_releaser);
+      _surfaceFactory = nullptr;
       _nativeSurface = nullptr;
     }
     // Release outside the lock: the platform may do real work here.
@@ -428,6 +453,32 @@ private:
   }
 
   // All *Locked helpers below require _mutex to be held exclusively.
+
+  static bool isDeviceLocked(const wgpu::Device &held,
+                             const wgpu::Device &device) {
+    return held != nullptr && held.Get() == device.Get();
+  }
+
+  // Release the Dawn surface. ~Surface detaches its swapchain (live or
+  // recycled), which needs that swapchain's device alive: _surfaceDevice
+  // guarantees it and is released only afterwards.
+  void dropSurfaceLocked() {
+    _surface = nullptr;
+    _surfaceDevice = nullptr;
+    // The in-flight frame (if any) rendered into the dropped surface;
+    // presentFrame() must not present it.
+    _acquiredFromSurface = false;
+  }
+
+  // Every Surface::Configure goes through here so _surfaceDevice tracks the
+  // device whose swapchain the surface holds (see unconfigureIfDevice).
+  void configureSurfaceLocked(const wgpu::SurfaceConfiguration &config) {
+    _surfaceDevice = config.device;
+    _surface.Configure(&config);
+#ifdef __APPLE__
+    applyCAMetalLayerColorSpace(_nativeSurface, config.format);
+#endif
+  }
 
   wgpu::Texture createOffscreenTextureLocked() {
     wgpu::TextureDescriptor descriptor;
@@ -456,7 +507,7 @@ private:
           wgpu::SurfaceGetCurrentTextureStatus::Error) {
         return nullptr;
       }
-      _surface.Configure(&_config);
+      configureSurfaceLocked(_config);
       _surface.GetCurrentTexture(&surfaceTexture);
       if (!isAcquireSuccess(surfaceTexture)) {
         return nullptr;
@@ -504,10 +555,7 @@ private:
 
   void _configureLocked() {
     if (_surface) {
-      _surface.Configure(&_config);
-#ifdef __APPLE__
-      applyCAMetalLayerColorSpace(_nativeSurface, _config.format);
-#endif
+      configureSurfaceLocked(_config);
     } else {
       _texture = createOffscreenTextureLocked();
     }
@@ -517,6 +565,12 @@ private:
   // Attached on-screen surface (null while offscreen).
   void *_nativeSurface = nullptr;
   wgpu::Surface _surface = nullptr;
+  // The device passed to the most recent Configure of _surface: the one its
+  // swapchain (live, or recycled by Unconfigure) is bound to. Holding the ref
+  // also keeps that device from being auto-destroyed when JS drops its last
+  // reference while the swapchain still exists. Null when _surface is null.
+  wgpu::Device _surfaceDevice = nullptr;
+  SurfaceFactory _surfaceFactory;
   NativeSurfaceReleaser _releaser;
   // Offscreen fallback drawing buffer.
   wgpu::Texture _texture = nullptr;
@@ -524,6 +578,7 @@ private:
   bool _hasPendingAttach = false;
   void *_pendingNativeSurface = nullptr;
   wgpu::Surface _pendingSurface = nullptr;
+  SurfaceFactory _pendingSurfaceFactory;
   NativeSurfaceReleaser _pendingReleaser;
   // Frame state: set by getCurrentTexture, cleared by presentFrame.
   bool _frameInFlight = false;
@@ -583,11 +638,12 @@ public:
   std::shared_ptr<SurfaceInfo> attachSurface(int id, wgpu::Instance gpu,
                                              int width, int height,
                                              void *nativeSurface,
-                                             wgpu::Surface surface,
+                                             SurfaceFactory makeSurface,
                                              NativeSurfaceReleaser releaser) {
     std::unique_lock<std::shared_mutex> lock(_mutex);
     auto info = getSurfaceInfoOrCreateLocked(id, gpu, width, height);
-    info->attachSurface(nativeSurface, std::move(surface), std::move(releaser));
+    info->attachSurface(nativeSurface, std::move(makeSurface),
+                        std::move(releaser));
     return info;
   }
 
@@ -611,12 +667,23 @@ public:
     _registry.clear();
   }
 
-  // Detach every surface configured with `device` before it is destroyed.
-  // Lock order is registry -> SurfaceInfo, matching every other path.
+  // Drop every Dawn surface holding a swapchain bound to `device` before it
+  // is destroyed; see SurfaceInfo::unconfigureIfDevice for why. Entries are
+  // snapshotted under the registry lock and visited outside it: a
+  // SurfaceInfo lock can be held across a frame acquire/present on its
+  // rendering thread, and waiting on that must not stall the UI thread's
+  // attach/remove paths. Lock order stays registry -> SurfaceInfo.
   void unconfigureDevice(const wgpu::Device &device) {
-    std::shared_lock<std::shared_mutex> lock(_mutex);
-    for (auto &entry : _registry) {
-      entry.second->unconfigureIfDevice(device);
+    std::vector<std::shared_ptr<SurfaceInfo>> infos;
+    {
+      std::shared_lock<std::shared_mutex> lock(_mutex);
+      infos.reserve(_registry.size());
+      for (auto &entry : _registry) {
+        infos.push_back(entry.second);
+      }
+    }
+    for (auto &info : infos) {
+      info->unconfigureIfDevice(device);
     }
   }
 

--- a/packages/webgpu/cpp/rnwgpu/SurfaceRegistry.h
+++ b/packages/webgpu/cpp/rnwgpu/SurfaceRegistry.h
@@ -254,13 +254,12 @@ public:
     _config.presentMode = wgpu::PresentMode::Fifo;
     _texture = nullptr;
     _frameEpoch++;
-    // The Dawn surface is dropped when its device is destroyed
-    // (unconfigureIfDevice) while the native window stays attached; a
-    // configure() with a replacement device is the standard recovery, so
-    // rebuild it here rather than rendering offscreen until the next attach.
-    if (!_surface && _nativeSurface && _surfaceFactory) {
-      _surface = _surfaceFactory(_nativeSurface);
-      _surfaceDevice = nullptr;
+    // The Dawn surface is dropped by unconfigure() and when its device is
+    // destroyed (unconfigureIfDevice) while the native window stays attached;
+    // configure() is the standard recovery from both, so rebuild it here
+    // rather than rendering offscreen until the next attach.
+    if (!_surface) {
+      createSurfaceLocked();
     }
     _configureLocked();
   }
@@ -280,13 +279,17 @@ public:
 
   void unconfigure() {
     std::unique_lock<std::shared_mutex> lock(_mutex);
-    if (_surface) {
-      _surface.Unconfigure();
-    }
+    // Drop the surface rather than Surface::Unconfigure it: Dawn parks the
+    // swapchain in the surface for reuse by the next Configure, and keeping
+    // that swapchain would keep its device pinned (through _surfaceDevice)
+    // behind an unconfigured canvas for as long as the canvas stays mounted.
+    // Releasing everything lets `context.unconfigure(); device = null` free
+    // the device as it does for a canvas without a surface; configure()
+    // rebuilds the surface from the factory.
+    dropSurfaceLocked();
     _texture = nullptr;
     _config = {};
     _viewFormats.clear();
-    _acquiredFromSurface = false;
     _frameEpoch++;
   }
 
@@ -301,11 +304,10 @@ public:
   // Removable once Dawn guards DetachFromSurfaceImpl against a destroyed
   // device.
   //
-  // The match is on _surfaceDevice, not only on _config.device: unconfigure()
-  // does not detach the swapchain, Dawn parks it in the surface for reuse by
-  // the next Configure (Surface::Unconfigure), so the spec-idiomatic
-  // `context.unconfigure(); device.destroy();` order leaves a swapchain bound
-  // to the destroyed device behind an unconfigured canvas.
+  // The match is on _surfaceDevice as well as _config.device: _surfaceDevice
+  // is what records which device's swapchain the surface holds, while
+  // matching _config.device also releases the offscreen drawing buffer of a
+  // canvas that has no surface.
   //
   // _config is kept: per spec a canvas whose device was destroyed stays
   // configured and hands out invalid textures, so a render loop that ticks
@@ -470,14 +472,45 @@ private:
     _acquiredFromSurface = false;
   }
 
+  // Create the Dawn surface for the attached native window. Requires _surface
+  // (and so _surfaceDevice) to be null. False when no window is attached or
+  // Dawn surface creation failed; the context then renders offscreen.
+  bool createSurfaceLocked() {
+    if (_nativeSurface && _surfaceFactory) {
+      _surface = _surfaceFactory(_nativeSurface);
+    }
+    return _surface != nullptr;
+  }
+
   // Every Surface::Configure goes through here so _surfaceDevice tracks the
   // device whose swapchain the surface holds (see unconfigureIfDevice).
-  void configureSurfaceLocked(const wgpu::SurfaceConfiguration &config) {
+  //
+  // A surface only ever carries one device's swapchain: when the device
+  // changes, the surface is rebuilt rather than reconfigured in place.
+  // Surface::Configure would detach the previous swapchain itself, but only
+  // after validating the new configuration, so a rejected one would leave the
+  // old device's swapchain live behind a surface now attributed to the new
+  // device (and invisible to unconfigureIfDevice). The detach also needs the
+  // old device alive: dropSurfaceLocked runs it before releasing
+  // _surfaceDevice, whereas reassigning _surfaceDevice first would let a
+  // device JS no longer references be destroyed mid-detach.
+  //
+  // Returns false when the surface had to be rebuilt and creation failed
+  // (_surface is then null and the caller falls back to offscreen).
+  bool configureSurfaceLocked(const wgpu::SurfaceConfiguration &config) {
+    if (_surfaceDevice != nullptr &&
+        !isDeviceLocked(_surfaceDevice, config.device)) {
+      dropSurfaceLocked();
+      if (!createSurfaceLocked()) {
+        return false;
+      }
+    }
     _surfaceDevice = config.device;
     _surface.Configure(&config);
 #ifdef __APPLE__
     applyCAMetalLayerColorSpace(_nativeSurface, config.format);
 #endif
+    return true;
   }
 
   wgpu::Texture createOffscreenTextureLocked() {
@@ -554,11 +587,10 @@ private:
   }
 
   void _configureLocked() {
-    if (_surface) {
-      configureSurfaceLocked(_config);
-    } else {
-      _texture = createOffscreenTextureLocked();
+    if (_surface && configureSurfaceLocked(_config)) {
+      return;
     }
+    _texture = createOffscreenTextureLocked();
   }
 
   mutable std::shared_mutex _mutex;

--- a/packages/webgpu/cpp/rnwgpu/api/GPUDevice.cpp
+++ b/packages/webgpu/cpp/rnwgpu/api/GPUDevice.cpp
@@ -16,6 +16,7 @@
 #include "GPUOutOfMemoryError.h"
 #include "GPUValidationError.h"
 #include "RnFeatures.h"
+#include "SurfaceRegistry.h"
 
 namespace rnwgpu {
 
@@ -149,6 +150,10 @@ std::shared_ptr<GPUCommandEncoder> GPUDevice::createCommandEncoder(
 }
 
 void GPUDevice::destroy() {
+  // Detach every swapchain bound to this device before destroying it, so the
+  // native surface teardown does not dereference a freed FencedDeleter (a
+  // SIGSEGV on the Vulkan backend when a Canvas unmounts).
+  rnwgpu::SurfaceRegistry::getInstance().unconfigureDevice(_instance);
   _instance.Destroy();
   notifyDeviceLost(wgpu::DeviceLostReason::Destroyed, "device was destroyed");
 }

--- a/packages/webgpu/cpp/rnwgpu/api/GPUDevice.cpp
+++ b/packages/webgpu/cpp/rnwgpu/api/GPUDevice.cpp
@@ -150,9 +150,8 @@ std::shared_ptr<GPUCommandEncoder> GPUDevice::createCommandEncoder(
 }
 
 void GPUDevice::destroy() {
-  // Detach every swapchain bound to this device before destroying it, so the
-  // native surface teardown does not dereference a freed FencedDeleter (a
-  // SIGSEGV on the Vulkan backend when a Canvas unmounts).
+  // Drop the swapchains bound to this device while it can still detach them;
+  // see SurfaceInfo::unconfigureIfDevice for the Dawn Vulkan bug behind it.
   rnwgpu::SurfaceRegistry::getInstance().unconfigureDevice(_instance);
   _instance.Destroy();
   notifyDeviceLost(wgpu::DeviceLostReason::Destroyed, "device was destroyed");

--- a/packages/webgpu/src/__tests__/Device.spec.ts
+++ b/packages/webgpu/src/__tests__/Device.spec.ts
@@ -118,6 +118,39 @@ describe("Device", () => {
     expect(["unknown", "destroyed"].includes(result.reason)).toBe(true);
   });
 
+  it("keeps a canvas configured after its device is destroyed", async () => {
+    // Per spec, destroying the device does not unconfigure the canvas: a
+    // render loop that ticks once more gets an invalid texture, not an
+    // InvalidStateError, and configure() with another device recovers.
+    const result = await client.eval(({ gpu, device, ctx }) =>
+      gpu
+        .requestAdapter()
+        .then((adapter) => adapter!.requestDevice())
+        .then((doomed) => {
+          const format = navigator.gpu.getPreferredCanvasFormat();
+          ctx.configure({ device: doomed, format, alphaMode: "premultiplied" });
+          ctx.getCurrentTexture();
+          doomed.destroy();
+          let threwAfterDestroy = false;
+          try {
+            ctx.getCurrentTexture();
+          } catch {
+            threwAfterDestroy = true;
+          }
+          ctx.configure({ device, format, alphaMode: "premultiplied" });
+          const texture = ctx.getCurrentTexture();
+          return {
+            threwAfterDestroy,
+            width: texture.width,
+            height: texture.height,
+          };
+        }),
+    );
+    expect(result.threwAfterDestroy).toBe(false);
+    expect(result.width).toBe(1024);
+    expect(result.height).toBe(1024);
+  });
+
   it("times out device.lost if the device has not been destroyed", async () => {
     const isDeviceLost = await client.eval(({ device }) => {
       const timeout = new Promise((resolve) => {


### PR DESCRIPTION
Fixes the native crash reported in #468.

## The bug

When a `<Canvas>` unmounts on Android, the app crashes about 2 out of 3 times with a SIGSEGV in Dawn's Vulkan backend:

```
F libc    : Fatal signal 11 (SIGSEGV), fault addr 0x20
  dawn::native::vulkan::FencedDeleter::DeleteWhenUnused
  dawn::native::vulkan::SwapChain::DetachFromSurfaceImpl
  dawn::native::Surface::~Surface
  rnwgpu::SurfaceInfo::detach(bool)
  Java_com_webgpu_WebGPUView_onViewDestroyed
```

iOS (Metal) never crashes with the same code.

## Root cause

three.js's `WebGPURenderer.dispose()` calls `device.destroy()` synchronously in the React effect cleanup. On Android the native view is dropped one frame later, so `SurfaceInfo::detach()` releases a `wgpu::Surface` whose swapchain is still attached. `~Surface` then runs `SwapChain::DetachFromSurfaceImpl`, which reads the already-destroyed device's `FencedDeleter`. That pointer is freed, so Dawn dereferences null at `0x20`.

Calling `Surface.Unconfigure()` at destroy time is not enough. What touches the device is the swapchain detach inside `~Surface`, so the surface has to be released (its destructor has to run) while the device is still alive.

## The fix

`GPUDevice::destroy()` now walks the `SurfaceRegistry` and, for every `SurfaceInfo` bound to this device, unconfigures and releases the `wgpu::Surface` right away, before `_instance.Destroy()`. Releasing it runs `~Surface` and `SwapChain::DetachFromSurface` against a live device. The native window pointer stays in `_nativeSurface`, so the later `SurfaceInfo::detach()` from the view teardown still returns the window to the platform.

Two small additions, with no change on the happy path. `SurfaceInfo::unconfigureIfDevice(device)` detaches and releases the surface when it belongs to `device`, and `SurfaceRegistry::unconfigureDevice(device)` calls it for every entry.

## Verification

Pixel emulator, Android API 37, `-gpu host` (real Vulkan via virtio-gpu), `minSdkVersion` 26, three.js `WebGPURenderer` rendering a glTF in a `<Canvas>` inside a React Navigation screen.

Before the fix: navigate in, wait for the first frame, press back, repeat. Crashes 2 out of 3 times.

After the fix: the same loop with `renderer.dispose()` called immediately in cleanup, no workaround on the app side. Five clean exits out of five, same PID throughout. Instrumentation confirms the `detach` after teardown now sees `surface=0`, already released.

It also runs on iOS, where `unconfigureDevice` is a cheap walk that does nothing but keeps both platforms on the same teardown path.

A standalone reproduction is at https://github.com/eduardoborges/react-native-webgpu-unmount-repro.
